### PR TITLE
[FEAT] 플레이어 리스트 컴포넌트 구현

### DIFF
--- a/packages/frontend/src/components/PlayerList/PlayerList.component.tsx
+++ b/packages/frontend/src/components/PlayerList/PlayerList.component.tsx
@@ -1,0 +1,33 @@
+import {
+  PlayerListLayout,
+  PersonnelCountParagraph,
+  PlayerItemList,
+} from "./PlayerList.styles";
+import PlayerListItem from "./PlayerListItem/PlayerListItem.component";
+
+import { GamePlayer } from "../../types/game";
+
+interface PlayerListProps {
+  sizeType: "medium" | "large";
+  players: GamePlayer[];
+  maxPlayer: number;
+}
+
+const PlayerList = ({ sizeType, players, maxPlayer }: PlayerListProps) => {
+  return (
+    <PlayerListLayout>
+      <PersonnelCountParagraph>{`${players.length}/${maxPlayer}`}</PersonnelCountParagraph>
+      <PlayerItemList>
+        {players.map((player) => (
+          <PlayerListItem
+            key={player.peerId}
+            sizeType={sizeType}
+            player={player}
+          />
+        ))}
+      </PlayerItemList>
+    </PlayerListLayout>
+  );
+};
+
+export default PlayerList;

--- a/packages/frontend/src/components/PlayerList/PlayerList.component.tsx
+++ b/packages/frontend/src/components/PlayerList/PlayerList.component.tsx
@@ -15,7 +15,7 @@ interface PlayerListProps {
 
 const PlayerList = ({ sizeType, players, maxPlayer }: PlayerListProps) => {
   return (
-    <PlayerListLayout>
+    <PlayerListLayout sizeType={sizeType}>
       <PersonnelCountParagraph>{`${players.length}/${maxPlayer}`}</PersonnelCountParagraph>
       <PlayerItemList>
         {players.map((player) => (

--- a/packages/frontend/src/components/PlayerList/PlayerList.styles.tsx
+++ b/packages/frontend/src/components/PlayerList/PlayerList.styles.tsx
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+export const PersonnelCountParagraph = styled.p`
+  padding: 4px 8px 6px 8px;
+  border-radius: 4px;
+  color: ${(props) => props.theme.colors.primary};
+  font-size: 1.15rem;
+  font-weight: bold;
+  background-color: ${(props) => props.theme.colors.primaryLightTransparent};
+`;
+
+export const PlayerItemList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const PlayerListLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: fit-content;
+  padding: 12px 24px 24px 24px;
+  background-color: ${(props) => props.theme.colors.primaryLightTransparent};
+
+  ${PersonnelCountParagraph} {
+    margin-bottom: 12px;
+  }
+`;

--- a/packages/frontend/src/components/PlayerList/PlayerList.styles.tsx
+++ b/packages/frontend/src/components/PlayerList/PlayerList.styles.tsx
@@ -1,4 +1,8 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
+
+interface PlayerListLayoutProps {
+  sizeType: "medium" | "large";
+}
 
 export const PersonnelCountParagraph = styled.p`
   padding: 4px 8px 6px 8px;
@@ -15,13 +19,26 @@ export const PlayerItemList = styled.ul`
   gap: 12px;
 `;
 
-export const PlayerListLayout = styled.div`
+export const PlayerListLayout = styled.div<PlayerListLayoutProps>`
   display: flex;
   flex-direction: column;
   align-items: center;
   width: fit-content;
   padding: 12px 24px 24px 24px;
   background-color: ${(props) => props.theme.colors.primaryLightTransparent};
+
+  /* size */
+  ${(props) =>
+    props.sizeType === "medium" &&
+    css`
+      height: 620px;
+    `}
+
+  ${(props) =>
+    props.sizeType === "large" &&
+    css`
+      width: 744px;
+    `}
 
   ${PersonnelCountParagraph} {
     margin-bottom: 12px;

--- a/packages/frontend/src/components/PlayerList/PlayerListItem/PlayerListItem.component.tsx
+++ b/packages/frontend/src/components/PlayerList/PlayerListItem/PlayerListItem.component.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+import {
+  PlayerListItemLayout,
+  RightSection,
+  LeftSection,
+  AvatarContainer,
+  Avatar,
+  Name,
+  Score,
+  IconConatiner,
+} from "./PlayerListItem.styles";
+
+import { GamePlayer } from "../../../types/game";
+import Icon from "../../Icon/Icon";
+
+interface PlayerListItemProps {
+  sizeType: "medium" | "large";
+  player: GamePlayer;
+}
+
+const PlayerListItem = ({ sizeType, player }: PlayerListItemProps) => {
+  const {
+    peerId,
+    userName,
+    avatarURL,
+    isHost,
+    isMicOn,
+    isCurrentTurn,
+    isReady,
+    score,
+  } = player;
+  const playerState = isReady ? "ready" : isCurrentTurn ? "turn" : "normal";
+
+  return (
+    <PlayerListItemLayout sizeType={sizeType} state={playerState}>
+      <RightSection>
+        <AvatarContainer>
+          {isHost && <Icon icon="check" size={20} />}
+          {avatarURL && <Avatar src={avatarURL} />}
+        </AvatarContainer>
+        <Name>{userName}</Name>
+      </RightSection>
+      <LeftSection>
+        {score !== undefined && <Score>{score}점</Score>}
+        <IconConatiner>
+          <Icon icon="mic-off" size={20} />
+        </IconConatiner>
+      </LeftSection>
+    </PlayerListItemLayout>
+  );
+};
+
+export default PlayerListItem;

--- a/packages/frontend/src/components/PlayerList/PlayerListItem/PlayerListItem.component.tsx
+++ b/packages/frontend/src/components/PlayerList/PlayerListItem/PlayerListItem.component.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import {
   PlayerListItemLayout,
   RightSection,

--- a/packages/frontend/src/components/PlayerList/PlayerListItem/PlayerListItem.styles.tsx
+++ b/packages/frontend/src/components/PlayerList/PlayerListItem/PlayerListItem.styles.tsx
@@ -1,0 +1,103 @@
+import styled, { css } from "styled-components";
+
+interface PlayerListItemLayoutProps {
+  sizeType: "medium" | "large";
+  state: "normal" | "ready" | "turn";
+}
+
+export const AvatarContainer = styled.div`
+  position: relative;
+  width: 40px;
+  height: 40px;
+  border: 2px solid ${(props) => props.theme.colors.primary};
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.5);
+
+  svg {
+    position: absolute;
+    top: -40%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+`;
+
+export const Avatar = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+export const Name = styled.p`
+  color: ${(props) => props.theme.colors.primary};
+`;
+
+export const Score = styled.p`
+  font-weight: bold;
+  white-space: nowrap;
+  color: ${(props) => props.theme.colors.primary};
+`;
+
+export const IconConatiner = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 36px;
+  height: 36px;
+  border: 3px solid ${(props) => props.theme.colors.primary};
+  border-radius: 50%;
+`;
+
+export const RightSection = styled.div`
+  display: flex;
+  align-items: center;
+
+  ${AvatarContainer} {
+    margin-right: 5px;
+  }
+`;
+
+export const LeftSection = styled.div`
+  display: flex;
+  align-items: center;
+
+  ${Score} {
+    margin-right: 5px;
+  }
+`;
+
+export const PlayerListItemLayout = styled.li<PlayerListItemLayoutProps>`
+  display: flex;
+  justify-content: space-between;
+  height: 52px;
+  padding: 4px 6px;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  background-color: ${(props) => props.theme.colors.primaryLight};
+
+  /* size */
+  ${(props) =>
+    props.sizeType === "medium" &&
+    css`
+      width: 284px;
+    `}
+
+  ${(props) =>
+    props.sizeType === "large" &&
+    css`
+      width: 432px;
+    `}
+
+  /* state => background color*/
+  ${(props) =>
+    props.state === "ready" &&
+    css`
+      background-color: ${(props) => props.theme.colors.green};
+    `}
+
+  ${(props) =>
+    props.state === "turn" &&
+    css`
+      background-color: ${(props) => props.theme.colors.yellow};
+    `}
+`;

--- a/packages/frontend/src/types/game.ts
+++ b/packages/frontend/src/types/game.ts
@@ -1,0 +1,13 @@
+export interface Player {
+  peerId: string;
+  userName: string;
+  avatarURL: string;
+  isHost: boolean;
+  isMicOn: boolean;
+}
+
+export interface GamePlayer extends Player {
+  isCurrentTurn?: boolean;
+  isReady?: boolean;
+  score?: number;
+}


### PR DESCRIPTION
## 관련 이슈

closes #37

## 작업 내역

- 필요한 인터페이스(Player, GamePlayer) 정의
- PlayerListItem 컴포넌트 구현
- PlayerList 컴포넌트 구현

## 새로운 이슈

- 상태 관리 형태가 아직 결정되지 않아 일단 플레이어 리스트 정보를 props로 받는 것으로 하였습니다.
- Icon에 crown이 없어 일단 check로 방장 표시를 구현했습니다.
