### PR TITLE
[FIX] 게임중 MoonTimer 재대로 작동 안하는 현상 수정

### DIFF
--- a/packages/frontend/src/components/MoonTimer/MoonTimer.component.tsx
+++ b/packages/frontend/src/components/MoonTimer/MoonTimer.component.tsx
@@ -10,6 +10,7 @@ interface MoonTimerProps {
 const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const startTimeRef = useRef(new Date());
+  const requestAnimationFrameIdRef = useRef(0);
 
   // progress: 0 ~ 1
   const calculateProgress = () => {
@@ -36,7 +37,9 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
     ctx.globalCompositeOperation = "source-over";
 
     if (progress >= 1) return;
-    requestAnimationFrame(() => moonAnimation(ctx));
+    requestAnimationFrameIdRef.current = requestAnimationFrame(() =>
+      moonAnimation(ctx)
+    );
   };
 
   useEffect(() => {
@@ -45,7 +48,13 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
     if (!canvas || !ctx) return;
     ctx.fillStyle = "rgb(255, 236, 180)";
 
-    moonAnimation(ctx);
+    requestAnimationFrameIdRef.current = requestAnimationFrame(() =>
+      moonAnimation(ctx)
+    );
+
+    return () => {
+      cancelAnimationFrame(requestAnimationFrameIdRef.current);
+    };
   }, []);
 
   return (

--- a/packages/frontend/src/components/MoonTimer/MoonTimer.component.tsx
+++ b/packages/frontend/src/components/MoonTimer/MoonTimer.component.tsx
@@ -45,7 +45,6 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
     ctx.ellipse(radius, radius, Math.abs(halfWidth), radius, 0, 0, 2 * Math.PI);
     ctx.fill();
     ctx.globalCompositeOperation = "source-over";
-
     if (progress >= 1) return;
     requestAnimationFrameIdRef.current = requestAnimationFrame(() =>
       moonAnimation(ctx)
@@ -55,6 +54,7 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
   const startMoonAnimation = () => {
     const ctx = getCanvasContext();
     if (!ctx) return;
+    startTimeRef.current = new Date();
     requestAnimationFrameIdRef.current = requestAnimationFrame(() =>
       moonAnimation(ctx)
     );
@@ -69,7 +69,7 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
     startMoonAnimation();
 
     return stopMoonAnimation;
-  }, []);
+  });
 
   return (
     <MoonTimerLayout ref={canvasRef} width={radius * 2} height={radius * 2} />

--- a/packages/frontend/src/components/MoonTimer/MoonTimer.component.tsx
+++ b/packages/frontend/src/components/MoonTimer/MoonTimer.component.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef } from "react";
 
 import { MoonTimerLayout } from "./MoonTimer.styles";
 
+import { colors } from "../../global-styles/theme";
+
 interface MoonTimerProps {
   secondTime: number;
   radius: number;
@@ -19,7 +21,7 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
   const initCanvas = () => {
     const ctx = getCanvasContext();
     if (!ctx) return;
-    ctx.fillStyle = "rgb(255, 236, 180)";
+    ctx.fillStyle = colors.yellow;
   };
 
   // progress: 0 ~ 1
@@ -36,15 +38,18 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
 
     // draw ellipse to center
     const progress = calculateProgress();
+
+    // halfWidth: -radius ~ radius
     const halfWidth = radius - radius * progress * 2;
 
-    // clear center by ellipse when progress < 0.5
+    // progress가 0.5 미만인 경우, 가운데를 투명화, progress가 0.5 이상인 경우, 가운데를 칠한다.
     if (halfWidth > 0) ctx.globalCompositeOperation = "destination-out";
-
     ctx.beginPath();
     ctx.ellipse(radius, radius, Math.abs(halfWidth), radius, 0, 0, 2 * Math.PI);
     ctx.fill();
+
     ctx.globalCompositeOperation = "source-over";
+
     if (progress >= 1) return;
     requestAnimationFrameIdRef.current = requestAnimationFrame(() =>
       moonAnimation(ctx)
@@ -66,6 +71,9 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
 
   useEffect(() => {
     initCanvas();
+  }, []);
+
+  useEffect(() => {
     startMoonAnimation();
 
     return stopMoonAnimation;

--- a/packages/frontend/src/components/MoonTimer/MoonTimer.component.tsx
+++ b/packages/frontend/src/components/MoonTimer/MoonTimer.component.tsx
@@ -12,6 +12,16 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
   const startTimeRef = useRef(new Date());
   const requestAnimationFrameIdRef = useRef(0);
 
+  const getCanvasContext = () => {
+    return canvasRef.current?.getContext("2d");
+  };
+
+  const initCanvas = () => {
+    const ctx = getCanvasContext();
+    if (!ctx) return;
+    ctx.fillStyle = "rgb(255, 236, 180)";
+  };
+
   // progress: 0 ~ 1
   const calculateProgress = () => {
     const elapsedSecond =
@@ -42,19 +52,23 @@ const MoonTimer = ({ secondTime, radius }: MoonTimerProps) => {
     );
   };
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    const ctx = canvas?.getContext("2d");
-    if (!canvas || !ctx) return;
-    ctx.fillStyle = "rgb(255, 236, 180)";
-
+  const startMoonAnimation = () => {
+    const ctx = getCanvasContext();
+    if (!ctx) return;
     requestAnimationFrameIdRef.current = requestAnimationFrame(() =>
       moonAnimation(ctx)
     );
+  };
 
-    return () => {
-      cancelAnimationFrame(requestAnimationFrameIdRef.current);
-    };
+  const stopMoonAnimation = () => {
+    cancelAnimationFrame(requestAnimationFrameIdRef.current);
+  };
+
+  useEffect(() => {
+    initCanvas();
+    startMoonAnimation();
+
+    return stopMoonAnimation;
   }, []);
 
   return (

--- a/packages/frontend/src/pages/GamePage/GamePage.component.tsx
+++ b/packages/frontend/src/pages/GamePage/GamePage.component.tsx
@@ -170,7 +170,7 @@ const GamePage = () => {
         </GamePageContentBox>
         <GamePageContentBox>
           {gameState === "drawing" ? (
-            <MoonTimer radius={50} secondTime={roundTime} />
+            <MoonTimer radius={50} secondTime={roundTime / 1000} />
           ) : (
             <MoonTimer radius={50} secondTime={Infinity} />
           )}


### PR DESCRIPTION
## 관련 이슈

closes #98

## 작업 내역

- MoonTimer는 secondTime을 받는데, ms 단위인 rountTime을 그대로 props로 전달해 문제 발생 -> 1000으로 나눠줌
- MoonTimer가 리렌더링시 새롭게 애니메이션을 시작하도록 코드 변경 -> 기존엔 mount시에만 애니메이션을 동작시켜서, 새로운 secondTime을 props로 넘겨도 반영이 안되고 이전 애니메이션이 계속 돌고있었음.
- useEffect 내부에 있던 동작을 함수로 추상화
- 색상 상수 사용
- 주석 보강