### PR TITLE
[FEAT] 갈틱폰 제시어 입력 단계

### DIFF
--- a/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
+++ b/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useAtom, useAtomValue } from "jotai";
+
+import Canvas from "../../components/Canvas/Canvas.component";
+import { CanvasLayout } from "../../components/Canvas/Canvas.styles";
+import Chat from "../../components/Chat/Chat.component";
+import { Button } from "../../components/common/Button";
+import { Input } from "../../components/common/Input";
+import Icon from "../../components/Icon/Icon";
+import { Logo } from "../../components/Logo/Logo.component";
+import MoonTimer from "../../components/MoonTimer/MoonTimer.component";
+import PaintBoard from "../../components/PaintBoard/PaintBoard.component";
+import {
+  KeywordInputLayout,
+  PaintBoardButtonLayout,
+} from "../../components/PaintBoard/PaintBoard.styles";
+import PaintToolBox from "../../components/PaintToolBox/PaintToolBox.component";
+import PlayerList from "../../components/PlayerList/PlayerList.component";
+import Rank from "../../components/Rank/Rank.component";
+import { useCatchMind } from "../../hooks/useCatchMind";
+import {
+  GamePageContentBox,
+  GamePageRoundParagraph,
+} from "../../pages/GamePage/GamePage.styles";
+import { gameInfoAtom } from "../../store/game";
+import { playersAtom } from "../../store/players";
+import { socketAtom } from "../../store/socket";
+
+const CatchMind = () => {
+  const [players, setPlayers] = useAtom(playersAtom);
+  const gameInfo = useAtomValue(gameInfoAtom);
+  const socket = useAtomValue(socketAtom);
+  const [keyword, setKeyword] = useState("");
+  const navigate = useNavigate();
+
+  const { gamePlayerList, gameState, isMyTurn, roundEndInfo, roundInfo } =
+    useCatchMind(socket, players, gameInfo.roundInfo);
+
+  const { roundTime, currentRound, turnPlayer } = roundInfo;
+
+  const getUserNameById = (id: string | undefined | null) => {
+    return gamePlayerList.find(({ peerId }) => peerId === id)?.userName;
+  };
+
+  const currentTurnUserName = getUserNameById(turnPlayer);
+
+  const onKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(e.target.value);
+  };
+
+  const onReady = () => {
+    socket.emit("round-ready");
+  };
+
+  const onKeywordSubmit = () => {
+    if (!keyword) return;
+    socket.emit("input-keyword", { keyword });
+  };
+
+  const onGoToRoomClick = () => {
+    navigate("/room", { replace: true });
+  };
+
+  const getHeaderElement = () => {
+    switch (gameState) {
+      case "inputKeyword":
+        return isMyTurn
+          ? "제시어를 입력해주세요"
+          : `${currentTurnUserName}님이 제시어를 입력하고 있습니다.`;
+      case "drawing":
+        return isMyTurn
+          ? `제시어: ${keyword}`
+          : "그림을 보고 제시어를 맞춰 주세요";
+      case "roundEnd":
+        return roundEndInfo?.roundWinner
+          ? `${getUserNameById(
+              roundEndInfo.roundWinner
+            )}님이 정답을 맞추셨습니다. 정답: ${roundEndInfo.suggestedWord}`
+          : `아무도 정답을 맞추지 못했습니다. 정답: ${roundEndInfo?.suggestedWord}`;
+      case "gameEnd":
+        return "최종 랭킹";
+      default:
+        return "잠시만요...";
+    }
+  };
+
+  const getCenterElement = () => {
+    switch (gameState) {
+      case "drawing":
+        if (isMyTurn) return <Canvas />;
+        return <CanvasLayout />;
+      case "gameEnd":
+        return (
+          <Rank
+            rankList={gamePlayerList
+              .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+              .map(({ userName, score }) => ({
+                userName,
+                score: score ?? 0,
+              }))}
+          />
+        );
+      case "inputKeyword":
+        return <CanvasLayout />;
+      case "roundEnd":
+        return <CanvasLayout />;
+      default:
+        return null;
+    }
+  };
+
+  const getFooterElement = () => {
+    switch (gameState) {
+      case "drawing":
+        return isMyTurn ? <PaintToolBox /> : null;
+      case "gameEnd":
+        return (
+          <Button variant="large" onClick={onGoToRoomClick}>
+            방으로 이동
+          </Button>
+        );
+      case "inputKeyword":
+        return isMyTurn ? (
+          <KeywordInputLayout>
+            <Input
+              variant="medium"
+              placeholder="제시어를 입력하세요."
+              onChange={onKeywordChange}
+            />
+          </KeywordInputLayout>
+        ) : null;
+      case "roundEnd":
+        return (
+          <PaintBoardButtonLayout>
+            <Button variant="icon">
+              <Icon icon="download" size={36} />
+            </Button>
+            <Button variant="large" onClick={onReady}>
+              다음 라운드로
+            </Button>
+          </PaintBoardButtonLayout>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      <GamePageContentBox>
+        <GamePageRoundParagraph>
+          {currentRound} / {gameInfo.totalRound}
+        </GamePageRoundParagraph>
+        <PlayerList maxPlayer={10} players={gamePlayerList} sizeType="medium" />
+      </GamePageContentBox>
+      <GamePageContentBox>
+        <Logo height={80} />
+        <PaintBoard
+          headerText={getHeaderElement()}
+          centerElement={getCenterElement()}
+          footerElement={getFooterElement()}
+        />
+      </GamePageContentBox>
+      <GamePageContentBox>
+        {gameState === "drawing" ? (
+          <MoonTimer radius={50} secondTime={roundTime} />
+        ) : (
+          <MoonTimer radius={50} secondTime={Infinity} />
+        )}
+        <Chat />
+        {gameState === "inputKeyword" && isMyTurn && (
+          <Button variant="large" onClick={onKeywordSubmit}>
+            완료
+          </Button>
+        )}
+      </GamePageContentBox>
+    </>
+  );
+};
+
+export default CatchMind;

--- a/packages/frontend/src/components/GameModeSegmentedControl/GameModeSegmentedControl.component.tsx
+++ b/packages/frontend/src/components/GameModeSegmentedControl/GameModeSegmentedControl.component.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import {
   GameModeSegmentedControlLayout,
   GameModeButtonLayout,
@@ -15,11 +13,17 @@ import {
   GAME_MODE_DESCRIPTION_MAP,
 } from "../../constants/game-mode";
 
-const GameModeSegmentedControl = () => {
-  const [selectedGameMode, setSelectedGameMode] = useState<GameMode>(
-    GAME_MODE_LIST[0]
-  );
+interface GameModeSegmentedControlProps {
+  selectedGameMode: "catchMind" | "garticPhone";
+  setSelectedGameMode: React.Dispatch<
+    React.SetStateAction<"catchMind" | "garticPhone">
+  >;
+}
 
+const GameModeSegmentedControl = ({
+  selectedGameMode,
+  setSelectedGameMode,
+}: GameModeSegmentedControlProps) => {
   const onChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setSelectedGameMode(e.target.value as GameMode);
   };

--- a/packages/frontend/src/components/Gartic/Gartic.component.tsx
+++ b/packages/frontend/src/components/Gartic/Gartic.component.tsx
@@ -1,0 +1,5 @@
+const Gartic = () => {
+  return <></>;
+};
+
+export default Gartic;

--- a/packages/frontend/src/components/Gartic/Gartic.component.tsx
+++ b/packages/frontend/src/components/Gartic/Gartic.component.tsx
@@ -1,5 +1,76 @@
+import { useAtomValue } from "jotai";
+
+import useGartic from "../../hooks/useGartic";
+import {
+  GamePageContentBox,
+  GamePageRoundParagraph,
+} from "../../pages/GamePage/GamePage.styles";
+import { gameInfoAtom } from "../../store/game";
+import Chat from "../Chat/Chat.component";
+import { Button } from "../common/Button";
+import { Logo } from "../Logo/Logo.component";
+import MoonTimer from "../MoonTimer/MoonTimer.component";
+import PaintBoard from "../PaintBoard/PaintBoard.component";
+import PlayerList from "../PlayerList/PlayerList.component";
+
 const Gartic = () => {
-  return <></>;
+  const {
+    gameState,
+    album,
+    garticPlayerList,
+    image,
+    isLastAlbum,
+    keyword,
+    roundInfo: { currentRound, roundTime },
+  } = useGartic();
+  const gameInfo = useAtomValue(gameInfoAtom);
+
+  const headerElementMap = {
+    gameStart: "",
+    drawing: "",
+    inputKeyword: "",
+    gameEnd: "",
+  };
+  const centerElementMap = {
+    gameStart: null,
+    drawing: null,
+    inputKeyword: null,
+    gameEnd: null,
+  };
+  const footerElementMap = {
+    gameStart: null,
+    drawing: null,
+    inputKeyword: null,
+    gameEnd: null,
+  };
+
+  return gameState !== "gameEnd" ? (
+    <>
+      <GamePageContentBox>
+        <GamePageRoundParagraph>
+          {currentRound} / {gameInfo.totalRound}
+        </GamePageRoundParagraph>
+        <PlayerList
+          maxPlayer={10}
+          players={garticPlayerList}
+          sizeType="medium"
+        />
+      </GamePageContentBox>
+      <GamePageContentBox>
+        <Logo height={80} />
+        <PaintBoard
+          headerText={headerElementMap[gameState]}
+          centerElement={centerElementMap[gameState]}
+          footerElement={footerElementMap[gameState]}
+        />
+      </GamePageContentBox>
+      <GamePageContentBox>
+        <MoonTimer radius={50} secondTime={roundTime} />
+        <Chat />
+        <Button variant="large">완료</Button>
+      </GamePageContentBox>
+    </>
+  ) : null;
 };
 
 export default Gartic;

--- a/packages/frontend/src/components/Gartic/Gartic.component.tsx
+++ b/packages/frontend/src/components/Gartic/Gartic.component.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { useAtomValue } from "jotai";
 
 import useGartic from "../../hooks/useGartic";
@@ -6,11 +8,15 @@ import {
   GamePageRoundParagraph,
 } from "../../pages/GamePage/GamePage.styles";
 import { gameInfoAtom } from "../../store/game";
+import { socketAtom } from "../../store/socket";
+import { CanvasLayout } from "../Canvas/Canvas.styles";
 import Chat from "../Chat/Chat.component";
 import { Button } from "../common/Button";
+import { Input } from "../common/Input";
 import { Logo } from "../Logo/Logo.component";
 import MoonTimer from "../MoonTimer/MoonTimer.component";
 import PaintBoard from "../PaintBoard/PaintBoard.component";
+import { KeywordInputLayout } from "../PaintBoard/PaintBoard.styles";
 import PlayerList from "../PlayerList/PlayerList.component";
 
 const Gartic = () => {
@@ -24,21 +30,63 @@ const Gartic = () => {
     roundInfo: { currentRound, roundTime },
   } = useGartic();
   const gameInfo = useAtomValue(gameInfoAtom);
+  const socket = useAtomValue(socketAtom);
+  const isDone =
+    garticPlayerList.find((player) => player.peerId === socket.id)?.isDone ??
+    false;
+  const [keywordInput, setKeywordInput] = useState("");
 
+  const onButtonClick = () => {
+    buttonClickMap[gameState]();
+  };
+
+  const keywordButtonClick = () => {
+    if (isDone) {
+      socket.emit("keyword-cancel");
+      return;
+    }
+    socket.emit("input-keyword", { keyword: keywordInput });
+  };
+
+  const onKeywordInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setKeywordInput(e.target.value);
+  };
+
+  const buttonClickMap = {
+    gameStart: keywordButtonClick,
+    drawing: () => {
+      return;
+    },
+    inputKeyword: () => {
+      return;
+    },
+    gameEnd: () => {
+      return;
+    },
+  };
   const headerElementMap = {
-    gameStart: "",
+    gameStart: "제시어를 입력해주세요",
     drawing: "",
     inputKeyword: "",
     gameEnd: "",
   };
   const centerElementMap = {
-    gameStart: null,
+    gameStart: <CanvasLayout />,
     drawing: null,
     inputKeyword: null,
     gameEnd: null,
   };
   const footerElementMap = {
-    gameStart: null,
+    gameStart: (
+      <KeywordInputLayout>
+        <Input
+          disabled={isDone}
+          variant="medium"
+          placeholder="제시어를 입력하세요."
+          onChange={onKeywordInputChange}
+        />
+      </KeywordInputLayout>
+    ),
     drawing: null,
     inputKeyword: null,
     gameEnd: null,
@@ -67,7 +115,13 @@ const Gartic = () => {
       <GamePageContentBox>
         <MoonTimer radius={50} secondTime={roundTime} />
         <Chat />
-        <Button variant="large">완료</Button>
+        <Button
+          variant="large"
+          onClick={onButtonClick}
+          disabled={!keywordInput}
+        >
+          {isDone ? "편집" : "완료"}
+        </Button>
       </GamePageContentBox>
     </>
   ) : null;

--- a/packages/frontend/src/hooks/useGartic.tsx
+++ b/packages/frontend/src/hooks/useGartic.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+
+import { useAtomValue } from "jotai";
+
+import { gameInfoAtom } from "../store/game";
+import { playersAtom } from "../store/players";
+import { socketAtom } from "../store/socket";
+import { GameInfo, GarticPlayer, GarticRoundInfo } from "../types/game";
+
+type GarticGameState = "gameStart" | "drawing" | "inputKeyword" | "gameEnd";
+
+interface AlbumResponse {
+  peerId: string;
+  isLast: boolean;
+  result: Album[];
+}
+interface Album {
+  peerId: string;
+  keyword?: string;
+  img?: string;
+}
+interface DrawStartResponse {
+  keyword: string;
+  roundInfo: GarticRoundInfo;
+}
+interface KeywordInputStartResponse {
+  img: string;
+  roundInfo: GarticRoundInfo;
+}
+
+const useGartic = () => {
+  const socket = useAtomValue(socketAtom);
+  const playerList = useAtomValue(playersAtom);
+  const gameInfo = useAtomValue(gameInfoAtom);
+  const [keyword, setKeyword] = useState("");
+  const [image, setImage] = useState("");
+  const [album, setAlbum] = useState<Album[]>([]);
+  const [roundInfo, setRoundInfo] = useState<GarticRoundInfo>(
+    gameInfo.roundInfo
+  );
+  const [gameState, setGameState] = useState<GarticGameState>("gameStart");
+  const [garticPlayerList, setGarticPlayerList] = useState<GarticPlayer[]>(
+    playerList.map((player) => ({
+      ...player,
+      isDone: false,
+      isMyResult: false,
+    }))
+  );
+  const [isLastAlbum, setIsLastAlbum] = useState(false);
+
+  useEffect(() => {
+    const gameStartListener = (gameStartResponse: GameInfo) => {
+      setGameState("gameStart");
+      setRoundInfo(gameStartResponse.roundInfo);
+    };
+    const drawStartListener = ({ keyword, roundInfo }: DrawStartResponse) => {
+      setKeyword(keyword);
+      setRoundInfo(roundInfo);
+      setGameState("drawing");
+    };
+    const keywordInputStartListener = ({
+      img,
+      roundInfo,
+    }: KeywordInputStartResponse) => {
+      setImage(img);
+      setRoundInfo(roundInfo);
+      setGameState("inputKeyword");
+    };
+    const gameEndListener = () => {
+      setGameState("gameEnd");
+    };
+    const setDoneOrNot = (peerId: string, isDone: boolean) => {
+      setGarticPlayerList((prev) => {
+        const copiedList = [...prev];
+        const donePlayerIndex = copiedList.findIndex(
+          (player) => player.peerId === peerId
+        );
+        copiedList[donePlayerIndex].isDone = isDone;
+        return copiedList;
+      });
+    };
+    const inputDoneListener = ({ peerId }: { peerId: string }) => {
+      setDoneOrNot(peerId, true);
+    };
+    const inputCancelListener = ({ peerId }: { peerId: string }) => {
+      setDoneOrNot(peerId, false);
+    };
+    const albumListener = ({ peerId, isLast, result }: AlbumResponse) => {
+      setGarticPlayerList((prev) => {
+        const copiedList = [...prev];
+        const convertMyResultToDone = copiedList.map((player) =>
+          player.isMyResult
+            ? { ...player, isMyResult: false, isDone: true }
+            : player
+        );
+        const currentPlayerIndex = convertMyResultToDone.findIndex(
+          (player) => player.peerId === peerId
+        );
+        convertMyResultToDone[currentPlayerIndex].isMyResult = true;
+        return convertMyResultToDone;
+      });
+      setIsLastAlbum(isLast);
+      setAlbum(result);
+    };
+
+    socket.on("game-start", gameStartListener);
+    socket.on("draw-start", drawStartListener);
+    socket.on("keyword-input-start", keywordInputStartListener);
+    socket.on("game-end", gameEndListener);
+    socket.on("input-keyword", inputDoneListener);
+    socket.on("keyword-cancel", inputCancelListener);
+    socket.on("draw-input", inputDoneListener);
+    socket.on("draw-cancel", inputCancelListener);
+    socket.on("game-end", gameEndListener);
+    socket.on("album", albumListener);
+    return () => {
+      socket.off("game-start", gameStartListener);
+      socket.off("draw-start", drawStartListener);
+      socket.off("keyword-input-start", keywordInputStartListener);
+      socket.off("game-end", gameEndListener);
+      socket.off("input-keyword", inputDoneListener);
+      socket.off("keyword-cancel", inputCancelListener);
+      socket.off("draw-input", inputDoneListener);
+      socket.off("draw-cancel", inputCancelListener);
+      socket.off("game-end", gameEndListener);
+      socket.off("album", albumListener);
+    };
+  }, [socket]);
+
+  return {
+    gameState,
+    garticPlayerList,
+    roundInfo,
+    keyword,
+    image,
+    album,
+    isLastAlbum,
+  };
+};
+
+export default useGartic;

--- a/packages/frontend/src/hooks/usePreventClose.tsx
+++ b/packages/frontend/src/hooks/usePreventClose.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+const usePreventClose = () => {
+  useEffect(() => {
+    const preventClose = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", preventClose);
+    return () => {
+      window.removeEventListener("beforeunload", preventClose);
+    };
+  }, []);
+};
+
+export default usePreventClose;

--- a/packages/frontend/src/pages/GamePage/GamePage.component.tsx
+++ b/packages/frontend/src/pages/GamePage/GamePage.component.tsx
@@ -1,190 +1,23 @@
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useAtom, useAtomValue } from "jotai";
+import { useAtomValue } from "jotai";
 
-import {
-  GamePageContentBox,
-  GamePageRoundParagraph,
-  GamePageLayout,
-} from "./GamePage.styles";
+import { GamePageLayout } from "./GamePage.styles";
 
-import Canvas from "../../components/Canvas/Canvas.component";
-import { CanvasLayout } from "../../components/Canvas/Canvas.styles";
-import Chat from "../../components/Chat/Chat.component";
-import { Button } from "../../components/common/Button";
-import { Input } from "../../components/common/Input";
-import Icon from "../../components/Icon/Icon";
-import { Logo } from "../../components/Logo/Logo.component";
-import MoonTimer from "../../components/MoonTimer/MoonTimer.component";
-import PaintBoard from "../../components/PaintBoard/PaintBoard.component";
-import {
-  KeywordInputLayout,
-  PaintBoardButtonLayout,
-} from "../../components/PaintBoard/PaintBoard.styles";
-import PaintToolBox from "../../components/PaintToolBox/PaintToolBox.component";
-import PlayerList from "../../components/PlayerList/PlayerList.component";
-import Rank from "../../components/Rank/Rank.component";
-import { useCatchMind } from "../../hooks/useCatchMind";
+import CatchMind from "../../components/CatchMind/CatchMind.component";
+import Gartic from "../../components/Gartic/Gartic.component";
+import usePreventClose from "../../hooks/usePreventClose";
 import { gameInfoAtom } from "../../store/game";
-import { playersAtom } from "../../store/players";
-import { socketAtom } from "../../store/socket";
 
 const GamePage = () => {
-  const [players, setPlayers] = useAtom(playersAtom);
   const gameInfo = useAtomValue(gameInfoAtom);
-  const socket = useAtomValue(socketAtom);
-  const [keyword, setKeyword] = useState("");
   const navigate = useNavigate();
-
-  const { gamePlayerList, gameState, isMyTurn, roundEndInfo, roundInfo } =
-    useCatchMind(socket, players, gameInfo.roundInfo);
-
-  const { roundTime, currentRound, turnPlayer } = roundInfo;
-
-  const getUserNameById = (id: string | undefined | null) => {
-    return gamePlayerList.find(({ peerId }) => peerId === id)?.userName;
-  };
-
-  const currentTurnUserName = getUserNameById(turnPlayer);
-
-  const onKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setKeyword(e.target.value);
-  };
-
-  const onReady = () => {
-    socket.emit("round-ready");
-  };
-
-  const onKeywordSubmit = () => {
-    if (!keyword) return;
-    socket.emit("input-keyword", { keyword });
-  };
-
-  const onGoToRoomClick = () => {
-    navigate("/room", { replace: true });
-  };
-
-  const getHeaderElement = () => {
-    switch (gameState) {
-      case "inputKeyword":
-        return isMyTurn
-          ? "제시어를 입력해주세요"
-          : `${currentTurnUserName}님이 제시어를 입력하고 있습니다.`;
-      case "drawing":
-        return isMyTurn
-          ? `제시어: ${keyword}`
-          : "그림을 보고 제시어를 맞춰 주세요";
-      case "roundEnd":
-        return roundEndInfo?.roundWinner
-          ? `${getUserNameById(
-              roundEndInfo.roundWinner
-            )}님이 정답을 맞추셨습니다. 정답: ${roundEndInfo.suggestedWord}`
-          : `아무도 정답을 맞추지 못했습니다. 정답: ${roundEndInfo?.suggestedWord}`;
-      case "gameEnd":
-        return "최종 랭킹";
-      default:
-        return "잠시만요...";
-    }
-  };
-
-  const getCenterElement = () => {
-    switch (gameState) {
-      case "drawing":
-        if (isMyTurn) return <Canvas />;
-        return <CanvasLayout />;
-      case "gameEnd":
-        return (
-          <Rank
-            rankList={gamePlayerList
-              .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
-              .map(({ userName, score }) => ({
-                userName,
-                score: score ?? 0,
-              }))}
-          />
-        );
-      case "inputKeyword":
-        return <CanvasLayout />;
-      case "roundEnd":
-        return <CanvasLayout />;
-      default:
-        return null;
-    }
-  };
-
-  const getFooterElement = () => {
-    switch (gameState) {
-      case "drawing":
-        return isMyTurn ? <PaintToolBox /> : null;
-      case "gameEnd":
-        return (
-          <Button variant="large" onClick={onGoToRoomClick}>
-            방으로 이동
-          </Button>
-        );
-      case "inputKeyword":
-        return isMyTurn ? (
-          <KeywordInputLayout>
-            <Input
-              variant="medium"
-              placeholder="제시어를 입력하세요."
-              onChange={onKeywordChange}
-            />
-          </KeywordInputLayout>
-        ) : null;
-      case "roundEnd":
-        return (
-          <PaintBoardButtonLayout>
-            <Button variant="icon">
-              <Icon icon="download" size={36} />
-            </Button>
-            <Button variant="large" onClick={onReady}>
-              다음 라운드로
-            </Button>
-          </PaintBoardButtonLayout>
-        );
-      default:
-        return null;
-    }
-  };
+  usePreventClose();
 
   return (
-    <>
-      <GamePageLayout>
-        <GamePageContentBox>
-          <GamePageRoundParagraph>
-            {currentRound} / {gameInfo.totalRound}
-          </GamePageRoundParagraph>
-          <PlayerList
-            maxPlayer={10}
-            players={gamePlayerList}
-            sizeType="medium"
-          />
-        </GamePageContentBox>
-        <GamePageContentBox>
-          <Logo height={80} />
-          <PaintBoard
-            headerText={getHeaderElement()}
-            centerElement={getCenterElement()}
-            footerElement={getFooterElement()}
-          />
-        </GamePageContentBox>
-        <GamePageContentBox>
-          {gameState === "drawing" ? (
-            <MoonTimer radius={50} secondTime={roundTime / 1000} />
-          ) : (
-            <MoonTimer radius={50} secondTime={Infinity} />
-          )}
-          <Chat />
-          {gameState === "inputKeyword" && isMyTurn && (
-            <Button variant="large" onClick={onKeywordSubmit}>
-              완료
-            </Button>
-          )}
-        </GamePageContentBox>
-      </GamePageLayout>
-    </>
+    <GamePageLayout>
+      {gameInfo.gameMode === "catchMind" ? <CatchMind /> : <Gartic />}
+    </GamePageLayout>
   );
 };
 

--- a/packages/frontend/src/pages/RoomPage/RoomPage.component.tsx
+++ b/packages/frontend/src/pages/RoomPage/RoomPage.component.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Navigate, useNavigate } from "react-router";
 
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -15,6 +15,8 @@ import { Button } from "../../components/common/Button";
 import GameModeSegmentedControl from "../../components/GameModeSegmentedControl/GameModeSegmentedControl.component";
 import { Logo } from "../../components/Logo/Logo.component";
 import PlayerList from "../../components/PlayerList/PlayerList.component";
+import { GameMode, GAME_MODE_LIST } from "../../constants/game-mode";
+import usePreventClose from "../../hooks/usePreventClose";
 import { gameInfoAtom } from "../../store/game";
 import { playersAtom } from "../../store/players";
 import { roomIdAtom } from "../../store/roomId";
@@ -28,6 +30,8 @@ const RoomPage = () => {
   const [players, setPlayers] = useAtom(playersAtom);
   const setGameInfo = useSetAtom(gameInfoAtom);
   const navigate = useNavigate();
+  const [gameMode, setGameMode] = useState<GameMode>(GAME_MODE_LIST[0]);
+  usePreventClose();
 
   const onInviteClick = () => {
     const inviteUrl = `${window.location.origin}/?invite=${roomId}`;
@@ -39,19 +43,8 @@ const RoomPage = () => {
 
   const onGameStartClick = () => {
     if (!isHost) return;
-    socket.emit("game-start", { gameMode: "catchMind" });
+    socket.emit("game-start", { gameMode });
   };
-
-  useEffect(() => {
-    const preventClose = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = "";
-    };
-    window.addEventListener("beforeunload", preventClose);
-    return () => {
-      window.removeEventListener("beforeunload", preventClose);
-    };
-  }, []);
 
   useEffect(() => {
     const gameStartListener = (gameStartResponse: GameInfo) => {
@@ -82,7 +75,10 @@ const RoomPage = () => {
       <RoomPageContentBox>
         <PlayerList maxPlayer={10} players={players} sizeType="large" />
         <RoomPageRightContentBox>
-          <GameModeSegmentedControl />
+          <GameModeSegmentedControl
+            selectedGameMode={gameMode}
+            setSelectedGameMode={setGameMode}
+          />
           <RoomPageButtonBox>
             <Button variant="medium" onClick={onInviteClick}>
               초대

--- a/packages/frontend/src/types/game.ts
+++ b/packages/frontend/src/types/game.ts
@@ -15,13 +15,18 @@ export interface GamePlayer extends Player {
 export interface GameInfo {
   gameMode: string;
   totalRound: number;
-  roundInfo: CatchMindRoundInfo;
+  roundInfo: CatchMindRoundInfo & GarticRoundInfo;
 }
 
 export interface CatchMindRoundInfo {
   roundTime: number;
   currentRound: number;
   turnPlayer: string;
+}
+
+export interface GarticRoundInfo {
+  roundTime: number;
+  currentRound: number;
 }
 
 type PlayerScoreMap = {
@@ -33,4 +38,9 @@ export interface CatchMindRoundEndInfo {
   suggestedWord: string;
   playerScoreMap: PlayerScoreMap;
   isLastRound: boolean;
+}
+
+export interface GarticPlayer extends Player {
+  isDone: boolean;
+  isMyResult: boolean;
 }


### PR DESCRIPTION
## 관련 이슈

closes #88 

## 작업 내역

- 게임 페이지 분리 (`GamePage.component.tsx` -> `CatchMind.component.tsx`, `Gartic.component.tsx`)
- 게임 모드 선택 컴포넌트 상태 외부에서 받도록 변경
- 새로고침 방지 코드 hook으로 분리
- useGartic 훅 구현
- 갈틱폰 컴포넌트 기본 구조 설정
- 제시어 입력 단계 구현