### PR TITLE
[FEAT] 갈틱폰 모드 그림 그리기 단계

### DIFF
--- a/packages/frontend/src/components/Canvas/Canvas.component.tsx
+++ b/packages/frontend/src/components/Canvas/Canvas.component.tsx
@@ -18,13 +18,16 @@ import { transparencyAtom } from "../../store/transparency";
 import { getCoordRelativeToElement } from "../../utils/coordinate";
 import { debounceByFrame } from "../../utils/debounce";
 
-const CANVAS_PROPS = {
+const CANVAS_SIZE = {
   WIDTH: 1036,
   HEIGHT: 644,
 };
 
-const Canvas = () => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+interface CanvasProps {
+  canvasRef: React.RefObject<HTMLCanvasElement>;
+}
+
+const Canvas = ({ canvasRef }: CanvasProps) => {
   const canvasImageData = useRef<ImageData | null>(null);
   const shapeList = useRef<Shape[]>([]);
   const isDrawing = useRef<boolean>(false);
@@ -38,7 +41,7 @@ const Canvas = () => {
     if (!ctx) return;
     ctx.lineCap = "round";
     ctx.lineJoin = "round";
-  }, []);
+  }, [canvasRef]);
 
   const captureCanvas = () => {
     const canvas = canvasRef.current;
@@ -141,7 +144,7 @@ const Canvas = () => {
     if ((e.metaKey || e.ctrlKey) && e.key === "z") {
       const ctx = canvasRef.current?.getContext("2d");
       shapeList.current.pop();
-      ctx?.clearRect(0, 0, CANVAS_PROPS.WIDTH, CANVAS_PROPS.HEIGHT);
+      ctx?.clearRect(0, 0, CANVAS_SIZE.WIDTH, CANVAS_SIZE.HEIGHT);
       canvasImageData.current = null;
       drawAllShapes();
     }
@@ -149,8 +152,8 @@ const Canvas = () => {
 
   return (
     <CanvasLayout
-      width={CANVAS_PROPS.WIDTH}
-      height={CANVAS_PROPS.HEIGHT}
+      width={CANVAS_SIZE.WIDTH}
+      height={CANVAS_SIZE.HEIGHT}
       ref={canvasRef}
       onMouseDown={drawStart}
       onMouseMove={draw}

--- a/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
+++ b/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAtom, useAtomValue } from "jotai";
@@ -34,6 +34,7 @@ const CatchMind = () => {
   const socket = useAtomValue(socketAtom);
   const [keyword, setKeyword] = useState("");
   const navigate = useNavigate();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const { gamePlayerList, gameState, isMyTurn, roundEndInfo, roundInfo } =
     useCatchMind(socket, players, gameInfo.roundInfo);
@@ -89,7 +90,7 @@ const CatchMind = () => {
   const getCenterElement = () => {
     switch (gameState) {
       case "drawing":
-        if (isMyTurn) return <Canvas />;
+        if (isMyTurn) return <Canvas canvasRef={canvasRef} />;
         return <CanvasLayout />;
       case "gameEnd":
         return (

--- a/packages/frontend/src/components/Gartic/Gartic.component.tsx
+++ b/packages/frontend/src/components/Gartic/Gartic.component.tsx
@@ -66,7 +66,7 @@ const Gartic = () => {
   };
   const headerElementMap = {
     gameStart: "제시어를 입력해주세요",
-    drawing: "",
+    drawing: `제시어: ${keyword}`,
     inputKeyword: "",
     gameEnd: "",
   };
@@ -114,7 +114,10 @@ const Gartic = () => {
         <Button
           variant="large"
           onClick={onButtonClick}
-          disabled={!keywordInput}
+          disabled={
+            (gameState === "gameStart" || gameState === "inputKeyword") &&
+            !keywordInput
+          }
         >
           {isDone ? "편집" : "완료"}
         </Button>

--- a/packages/frontend/src/components/Gartic/Gartic.component.tsx
+++ b/packages/frontend/src/components/Gartic/Gartic.component.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useRef, useState } from "react";
 
 import { useAtomValue } from "jotai";
 
@@ -9,6 +9,7 @@ import {
 } from "../../pages/GamePage/GamePage.styles";
 import { gameInfoAtom } from "../../store/game";
 import { socketAtom } from "../../store/socket";
+import Canvas from "../Canvas/Canvas.component";
 import { CanvasLayout } from "../Canvas/Canvas.styles";
 import Chat from "../Chat/Chat.component";
 import { Button } from "../common/Button";
@@ -17,6 +18,7 @@ import { Logo } from "../Logo/Logo.component";
 import MoonTimer from "../MoonTimer/MoonTimer.component";
 import PaintBoard from "../PaintBoard/PaintBoard.component";
 import { KeywordInputLayout } from "../PaintBoard/PaintBoard.styles";
+import PaintToolBox from "../PaintToolBox/PaintToolBox.component";
 import PlayerList from "../PlayerList/PlayerList.component";
 
 const Gartic = () => {
@@ -35,10 +37,10 @@ const Gartic = () => {
     garticPlayerList.find((player) => player.peerId === socket.id)?.isDone ??
     false;
   const [keywordInput, setKeywordInput] = useState("");
-
   const onButtonClick = () => {
     buttonClickMap[gameState]();
   };
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const keywordButtonClick = () => {
     if (isDone) {
@@ -72,7 +74,7 @@ const Gartic = () => {
   };
   const centerElementMap = {
     gameStart: <CanvasLayout />,
-    drawing: null,
+    drawing: <Canvas canvasRef={canvasRef} />,
     inputKeyword: null,
     gameEnd: null,
   };
@@ -87,7 +89,7 @@ const Gartic = () => {
         />
       </KeywordInputLayout>
     ),
-    drawing: null,
+    drawing: <PaintToolBox />,
     inputKeyword: null,
     gameEnd: null,
   };

--- a/packages/frontend/src/components/Gartic/Gartic.component.tsx
+++ b/packages/frontend/src/components/Gartic/Gartic.component.tsx
@@ -37,9 +37,6 @@ const Gartic = () => {
     garticPlayerList.find((player) => player.peerId === socket.id)?.isDone ??
     false;
   const [keywordInput, setKeywordInput] = useState("");
-  const onButtonClick = () => {
-    buttonClickMap[gameState]();
-  };
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const keywordButtonClick = () => {
@@ -54,11 +51,19 @@ const Gartic = () => {
     setKeywordInput(e.target.value);
   };
 
+  const drawingButtonClick = () => {
+    if (isDone) {
+      socket.emit("draw-cancel");
+      return;
+    }
+    if (!canvasRef.current) return;
+    const img = canvasRef.current.toDataURL();
+    socket.emit("draw-input", { img });
+  };
+
   const buttonClickMap = {
     gameStart: keywordButtonClick,
-    drawing: () => {
-      return;
-    },
+    drawing: drawingButtonClick,
     inputKeyword: () => {
       return;
     },
@@ -115,7 +120,7 @@ const Gartic = () => {
         <Chat />
         <Button
           variant="large"
-          onClick={onButtonClick}
+          onClick={buttonClickMap[gameState]}
           disabled={
             (gameState === "gameStart" || gameState === "inputKeyword") &&
             !keywordInput


### PR DESCRIPTION
## 관련 이슈

closes #90 

## 작업 내역

- 제시어 렌더링
- 캔버스 렌더링
  - 그림을 data URL로 변환해서 받기 위해 Canvas 컴포넌트의 canvasRef를 props로 받도록 변경
- 완료 버튼 클릭 시 data URL로 변환된 그림을 서버로 전송