### PR TITLE
[FIX] join 이벤트 시 전달 데이터 변경

### DIFF
--- a/packages/backend/src/domains/room/entity/room.service.ts
+++ b/packages/backend/src/domains/room/entity/room.service.ts
@@ -1,3 +1,4 @@
+import { Player } from "../../player/entity/player.entitiy";
 import { RoomPort } from "../inbound/room.port";
 import { RoomApiAdapter } from "../outbound/room.api.adapter";
 import { RoomEventAdapter } from "../outbound/room.event.adapter";
@@ -37,17 +38,19 @@ export class RoomService implements RoomPort {
       this.roomEventEmitter.join(
         {
           roomId: newRoom.roomId,
-          players: players.map((player) => {
-            if (newRoom.players.includes(player.peerId)) {
-              return {
-                peerId: player.peerId,
-                userName: player.userName,
-                avataURL: player.avata,
-                isHost: player.peerId === newRoom.host,
-                isMicOn: player.isMicOn,
-              };
-            }
-          }) as PlayerInfo[],
+          players: newRoom.players.map((peerId) => {
+            const player = players.find((player) => {
+              return player.peerId === peerId;
+            }) as Player;
+
+            return {
+              peerId: player.peerId,
+              userName: player.userName,
+              avataURL: player.avata,
+              isHost: player.peerId === newRoom.host,
+              isMicOn: player.isMicOn,
+            };
+          }),
         },
         peerId
       );
@@ -62,17 +65,19 @@ export class RoomService implements RoomPort {
     this.roomEventEmitter.join(
       {
         roomId: room.roomId,
-        players: players.map((player) => {
-          if (room.players.includes(player.peerId)) {
-            return {
-              peerId: player.peerId,
-              userName: player.userName,
-              avataURL: player.avata,
-              isHost: player.peerId === room.host,
-              isMicOn: player.isMicOn,
-            };
-          }
-        }) as PlayerInfo[],
+        players: room.players.map((peerId) => {
+          const player = players.find((player) => {
+            return player.peerId === peerId;
+          }) as Player;
+
+          return {
+            peerId: player.peerId,
+            userName: player.userName,
+            avataURL: player.avata,
+            isHost: player.peerId === room.host,
+            isMicOn: player.isMicOn,
+          };
+        }),
       },
       peerId
     );


### PR DESCRIPTION
## 관련 이슈
closes #131
## 작업 내역
- 기존에는 전체 플레이어 리스트를 기준으로 map을 하였으나 방에 없으면 null 이 들어가는 오류가 있었음
- room에 있는 플레이어 리스트를 기준으로 map을 하는 걸로 변경함