### PR TITLE
[FEAT] 갈틱폰 모드 제시어 유추 단계

### DIFF
--- a/packages/frontend/src/components/Canvas/Canvas.component.tsx
+++ b/packages/frontend/src/components/Canvas/Canvas.component.tsx
@@ -12,16 +12,12 @@ import Rectangle from "./utils/Rectangle";
 import Shape from "./utils/Shape";
 import straightLine from "./utils/StraightLine";
 
+import { CANVAS_SIZE } from "../../constants/canvas";
 import { thicknessAtom } from "../../store/thickness";
 import { toolAtom, paletteAtom } from "../../store/tool";
 import { transparencyAtom } from "../../store/transparency";
 import { getCoordRelativeToElement } from "../../utils/coordinate";
 import { debounceByFrame } from "../../utils/debounce";
-
-const CANVAS_SIZE = {
-  WIDTH: 1036,
-  HEIGHT: 644,
-};
 
 interface CanvasProps {
   canvasRef: React.RefObject<HTMLCanvasElement>;

--- a/packages/frontend/src/components/Gartic/Gartic.component.tsx
+++ b/packages/frontend/src/components/Gartic/Gartic.component.tsx
@@ -1,7 +1,8 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { useAtomValue } from "jotai";
 
+import { CANVAS_SIZE } from "../../constants/canvas";
 import useGartic from "../../hooks/useGartic";
 import {
   GamePageContentBox,
@@ -74,13 +75,13 @@ const Gartic = () => {
   const headerElementMap = {
     gameStart: "제시어를 입력해주세요",
     drawing: `제시어: ${keyword}`,
-    inputKeyword: "",
+    inputKeyword: "그림을 보고 제시어를 입력해주세요.",
     gameEnd: "",
   };
   const centerElementMap = {
     gameStart: <CanvasLayout />,
     drawing: <Canvas canvasRef={canvasRef} />,
-    inputKeyword: null,
+    inputKeyword: <CanvasLayout ref={canvasRef} />,
     gameEnd: null,
   };
   const footerElementMap = {
@@ -98,6 +99,21 @@ const Gartic = () => {
     inputKeyword: null,
     gameEnd: null,
   };
+
+  useEffect(() => {
+    const context = canvasRef.current?.getContext("2d");
+    const convertedImage = new Image();
+    convertedImage.src = image;
+    convertedImage.onload = () => {
+      context?.drawImage(
+        convertedImage,
+        0,
+        0,
+        CANVAS_SIZE.WIDTH,
+        CANVAS_SIZE.HEIGHT
+      );
+    };
+  }, [image]);
 
   return gameState !== "gameEnd" ? (
     <>

--- a/packages/frontend/src/components/Gartic/Gartic.component.tsx
+++ b/packages/frontend/src/components/Gartic/Gartic.component.tsx
@@ -65,9 +65,7 @@ const Gartic = () => {
   const buttonClickMap = {
     gameStart: keywordButtonClick,
     drawing: drawingButtonClick,
-    inputKeyword: () => {
-      return;
-    },
+    inputKeyword: keywordButtonClick,
     gameEnd: () => {
       return;
     },
@@ -96,9 +94,22 @@ const Gartic = () => {
       </KeywordInputLayout>
     ),
     drawing: <PaintToolBox />,
-    inputKeyword: null,
+    inputKeyword: (
+      <KeywordInputLayout>
+        <Input
+          disabled={isDone}
+          variant="medium"
+          placeholder="제시어를 입력하세요."
+          onChange={onKeywordInputChange}
+        />
+      </KeywordInputLayout>
+    ),
     gameEnd: null,
   };
+
+  useEffect(() => {
+    setKeywordInput("");
+  }, [gameState]);
 
   useEffect(() => {
     const context = canvasRef.current?.getContext("2d");

--- a/packages/frontend/src/constants/canvas.ts
+++ b/packages/frontend/src/constants/canvas.ts
@@ -1,0 +1,6 @@
+const CANVAS_SIZE = {
+  WIDTH: 1036,
+  HEIGHT: 644,
+};
+
+export { CANVAS_SIZE };


### PR DESCRIPTION
## 관련 이슈

closes #94 

## 작업 내역

- 캔버스 크기 상수(`CANVAS_SIZE`) 모듈 분리
- 다른 사람의 그림 표시
- 제시어 입력 및 입력한 제시어 서버로 전송