### PR TITLE
[FEAT] 게임 종료 이벤트 및 앨범 보내기 기능

### DIFF
--- a/packages/backend/src/domains/garticphone/entity/garticphone.service.ts
+++ b/packages/backend/src/domains/garticphone/entity/garticphone.service.ts
@@ -24,6 +24,30 @@ export class GarticphoneService implements GarticphonePort {
     this.repository.save(game);
   }
 
+  sendAlbum(roomId: string) {
+    const game = this.repository.findById(roomId);
+    if (!game) return;
+
+    const player = game.nextPlayer();
+    if (!player) return;
+
+    const AlbumData = {
+      peerId: player.id,
+      isLast: game.isLastAlbum,
+      result: player.getAlbum().map((data) => {
+        return {
+          peerId: data.ownerId,
+          keyword: data.type === "keyword" ? data.data : null,
+          img: data.type === "painting" ? data.data : null,
+        };
+      }),
+    };
+
+    this.eventEmitter.sendAlbum(roomId, AlbumData);
+
+    this.repository.save(game);
+  }
+
   timeOut(roomId: string) {
     this.eventEmitter.timeOut(roomId);
   }
@@ -53,23 +77,25 @@ export class GarticphoneService implements GarticphonePort {
     const players = game.getPlayerList();
     const roundInfo = game.roundData;
 
-    if (game.currentRoundType === "keyword") {
-      players.forEach((player) => {
-        const target = game.getAlbumOwner(player.id, game.currentRound);
-        if (!target) return;
+    players.forEach((player) => {
+      const target = game.getAlbumOwner(player.id, game.currentRound);
+      if (!target) return;
 
-        const lastData = target.getLastAlbumData();
-        this.eventEmitter.keywordInputStart(player.id, lastData, roundInfo);
-      });
-    } else {
-      players.forEach((player) => {
-        const target = game.getAlbumOwner(player.id, game.currentRound);
-        if (!target) return;
+      const lastData = target.getLastAlbumData();
+      const type = game.currentRoundType;
+      const data = {
+        keyword: type === "keyword" ? lastData : null,
+        img: type === "painting" ? lastData : null,
+        roundInfo,
+      };
 
-        const lastData = target.getLastAlbumData();
-        this.eventEmitter.drawStart(player.id, lastData, roundInfo);
-      });
-    }
+      this.eventEmitter.roundstart(player.id, type, data);
+    });
+
+    const timerId = setTimeout(() => this.timeOut(game.roomId), game.roundTime);
+    game.setTimer(timerId);
+
+    this.repository.save(game);
   }
 
   cancelAlbumData(roomId: string, playerId: string) {

--- a/packages/backend/src/domains/garticphone/entity/garticphone.service.ts
+++ b/packages/backend/src/domains/garticphone/entity/garticphone.service.ts
@@ -39,7 +39,7 @@ export class GarticphoneService implements GarticphonePort {
       clearTimeout(game.timerId);
 
       if (game.isGameEnded) {
-        return;
+        this.eventEmitter.gameEnd(roomId);
       } else {
         game.roundEnd();
         this.roundStart(game);

--- a/packages/backend/src/domains/garticphone/entity/garticphone.ts
+++ b/packages/backend/src/domains/garticphone/entity/garticphone.ts
@@ -2,7 +2,7 @@ import Crypto from "crypto";
 
 type DataType = "keyword" | "painting";
 
-class AlbumData {
+export class AlbumData {
   type: DataType;
   ownerId: string;
   data: string;
@@ -14,7 +14,7 @@ class AlbumData {
   }
 }
 
-class Player {
+export class Player {
   id: string;
   isInputEnded: boolean;
   album: AlbumData[] = [];
@@ -53,6 +53,7 @@ export class Garticphone {
   timerId: NodeJS.Timer | undefined;
   roundTime: number;
   roomId: string;
+  sendIdx: number;
 
   constructor(players: string[], roundTime: number, roomId: string) {
     this.players = players.map((playerId) => new Player(playerId));
@@ -60,6 +61,7 @@ export class Garticphone {
     this.roundTime = roundTime;
     this.roomId = roomId;
     this.currentRound = 1;
+    this.sendIdx = 0;
   }
 
   get currentRoundType() {
@@ -79,6 +81,10 @@ export class Garticphone {
 
   get isGameEnded() {
     return this.totalRound === this.currentRound;
+  }
+
+  get isLastAlbum() {
+    return this.players.length === this.sendIdx + 1;
   }
 
   cancelAlbumData(playerId: string) {
@@ -109,12 +115,8 @@ export class Garticphone {
     return this.players[currentIdx];
   }
 
-  getAlbum(playerId: string): AlbumData[] | undefined {
-    const player = this.players.find((player) => player.id === playerId);
-
-    if (!player) return;
-
-    return player.album;
+  nextPlayer() {
+    return this.players[this.sendIdx++];
   }
 
   getPlayerList() {
@@ -123,6 +125,7 @@ export class Garticphone {
 
   roundEnd() {
     this.currentRound++;
+    this.players.forEach((player) => (player.isInputEnded = false));
   }
 
   setTimer(timerId: NodeJS.Timer) {

--- a/packages/backend/src/domains/garticphone/inbound/garticphone.controller.ts
+++ b/packages/backend/src/domains/garticphone/inbound/garticphone.controller.ts
@@ -38,6 +38,11 @@ router.get("keyword-cancel", (socket: Socket) => {
   cancelInput(socket.id);
 });
 
+router.get("request-album", (socket: Socket) => {
+  const room = connecter.call("room/get-by-playerId", { id: socket.id });
+  if (room) service.sendAlbum(room.roomId);
+});
+
 connecter.register(
   "garticphone/game-start",
   ({

--- a/packages/backend/src/domains/garticphone/inbound/garticphone.port.ts
+++ b/packages/backend/src/domains/garticphone/inbound/garticphone.port.ts
@@ -2,4 +2,5 @@ export interface GarticphonePort {
   startGame: (roomId: string, roundTime: number, players: string[]) => void;
   setAlbumData: (roomId: string, playerId: string, data: string) => void;
   cancelAlbumData: (roomId: string, playerId: string) => void;
+  sendAlbum: (roomId: string) => void;
 }

--- a/packages/backend/src/domains/garticphone/outbound/garticphoneEvent.adapter.ts
+++ b/packages/backend/src/domains/garticphone/outbound/garticphoneEvent.adapter.ts
@@ -37,4 +37,8 @@ export class GarticphoneEventAdapter implements GarticphoneEventPort {
       roundInfo,
     });
   }
+
+  gameEnd(roomId: string) {
+    this.emitter.broadcastRoom(roomId, "game-end");
+  }
 }

--- a/packages/backend/src/domains/garticphone/outbound/garticphoneEvent.adapter.ts
+++ b/packages/backend/src/domains/garticphone/outbound/garticphoneEvent.adapter.ts
@@ -1,9 +1,13 @@
 import { SocketEmitter } from "../../../utils/socketEmitter";
+
 import {
   GarticphoneEventPort,
   GarticStartData,
-  GarticRoundInfo,
+  GarticAlbum,
+  GarticRoundData,
 } from "./garticphoneEvent.port";
+
+const EVENT_NAME = { painting: "draw-start", keyword: "keyword-input-start" };
 
 export class GarticphoneEventAdapter implements GarticphoneEventPort {
   emitter: SocketEmitter = new SocketEmitter();
@@ -24,21 +28,19 @@ export class GarticphoneEventAdapter implements GarticphoneEventPort {
     this.emitter.broadcastRoom(roomId, "time-out");
   }
 
-  drawStart(playerId: string, keyword: string, roundInfo: GarticRoundInfo) {
-    this.emitter.emit(playerId, "draw-start", {
-      keyword,
-      roundInfo,
-    });
-  }
-
-  keywordInputStart(playerId: string, img: string, roundInfo: GarticRoundInfo) {
-    this.emitter.emit(playerId, "keyword-input-start", {
-      img,
-      roundInfo,
-    });
+  roundstart(
+    playerId: string,
+    roundType: "painting" | "keyword",
+    data: GarticRoundData
+  ) {
+    this.emitter.emit(playerId, EVENT_NAME[roundType], data);
   }
 
   gameEnd(roomId: string) {
     this.emitter.broadcastRoom(roomId, "game-end");
+  }
+
+  sendAlbum(roomId: string, data: GarticAlbum) {
+    this.emitter.broadcastRoom(roomId, "game-end", data);
   }
 }

--- a/packages/backend/src/domains/garticphone/outbound/garticphoneEvent.port.ts
+++ b/packages/backend/src/domains/garticphone/outbound/garticphoneEvent.port.ts
@@ -24,4 +24,5 @@ export interface GarticphoneEventPort {
     img: string,
     roundInfo: GarticRoundInfo
   ) => void;
+  gameEnd: (roomId: string) => void;
 }

--- a/packages/backend/src/domains/garticphone/outbound/garticphoneEvent.port.ts
+++ b/packages/backend/src/domains/garticphone/outbound/garticphoneEvent.port.ts
@@ -9,20 +9,29 @@ export interface GarticStartData {
   roundInfo: GarticRoundInfo;
 }
 
+export interface GarticAlbum {
+  peerId: string;
+  isLast: boolean;
+  result: { peerId: string; keyword?: string | null; img?: string | null }[];
+}
+
+export interface GarticRoundData {
+  keyword: string | null;
+  img: string | null;
+  roundInfo: GarticRoundInfo;
+}
+
 export interface GarticphoneEventPort {
   gameStart: (roomId: string, data: GarticStartData) => void;
   keywordInput: (roomId: string, playerId: string) => void;
   keywordCancel: (roomId: string, playerId: string) => void;
   timeOut: (roomId: string) => void;
-  drawStart: (
+
+  roundstart: (
     playerId: string,
-    keyword: string,
-    roundInfo: GarticRoundInfo
-  ) => void;
-  keywordInputStart: (
-    playerId: string,
-    img: string,
-    roundInfo: GarticRoundInfo
+    roundType: "painting" | "keyword",
+    data: GarticRoundData
   ) => void;
   gameEnd: (roomId: string) => void;
+  sendAlbum: (roomId: string, data: GarticAlbum) => void;
 }


### PR DESCRIPTION
## 관련 이슈

#95 #96

## 작업 내역

- 마지막 라운드에 모든 사람에게서 입력을 받으면 게임 종료 이벤트 송신
- 게임 종료 앨범 데이터 요청마다 보내줌