### PR TITLE
[FEAT] 캐치마인드 캔버스 공유 구현

### DIFF
--- a/packages/backend/src/domains/room/outbound/room.api.adapter.ts
+++ b/packages/backend/src/domains/room/outbound/room.api.adapter.ts
@@ -21,7 +21,7 @@ export class RoomApiAdapter implements RoomApiPort {
     // if or switch로 거르기 -> game Mode;
 
     switch (gameMode) {
-      case "Garticphone":
+      case "garticphone":
         this.connecter.call("garticphone/game-start", {
           roomId,
           roundTime,
@@ -29,7 +29,7 @@ export class RoomApiAdapter implements RoomApiPort {
         });
         break;
 
-      case "CatchMind":
+      case "catchMind":
         this.connecter.call("catchMind/game-start", {
           goalScore,
           players,

--- a/packages/frontend/src/components/Canvas/Canvas.component.tsx
+++ b/packages/frontend/src/components/Canvas/Canvas.component.tsx
@@ -47,10 +47,15 @@ const Canvas = ({ canvasRef, setOutgoingCanvasStream }: CanvasProps) => {
   }, []);
 
   useEffect(() => {
+    const canvas = canvasRef.current;
     const ctx = canvasRef.current?.getContext("2d");
-    if (!ctx) return;
+    if (!canvas || !ctx) return;
+
+    const { width, height } = canvas;
     ctx.lineCap = "round";
     ctx.lineJoin = "round";
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, width, height);
   }, [canvasRef]);
 
   const captureCanvas = () => {

--- a/packages/frontend/src/components/Canvas/Canvas.component.tsx
+++ b/packages/frontend/src/components/Canvas/Canvas.component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { SetStateAction, useEffect, useRef } from "react";
 
 import { useAtom } from "jotai";
 import { useAtomValue } from "jotai/utils";
@@ -25,9 +25,10 @@ const CANVAS_SIZE = {
 
 interface CanvasProps {
   canvasRef: React.RefObject<HTMLCanvasElement>;
+  setOutgoingCanvasStream: React.Dispatch<SetStateAction<MediaStream | null>>;
 }
 
-const Canvas = ({ canvasRef }: CanvasProps) => {
+const Canvas = ({ canvasRef, setOutgoingCanvasStream }: CanvasProps) => {
   const canvasImageData = useRef<ImageData | null>(null);
   const shapeList = useRef<Shape[]>([]);
   const isDrawing = useRef<boolean>(false);
@@ -35,6 +36,15 @@ const Canvas = ({ canvasRef }: CanvasProps) => {
   const [transparency] = useAtom(transparencyAtom);
   const [color] = useAtom(paletteAtom);
   const thickness = useAtomValue(thicknessAtom);
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    setOutgoingCanvasStream(canvasRef.current.captureStream());
+
+    return () => {
+      setOutgoingCanvasStream(null);
+    };
+  }, []);
 
   useEffect(() => {
     const ctx = canvasRef.current?.getContext("2d");

--- a/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
+++ b/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
@@ -27,6 +27,7 @@ import {
 import { gameInfoAtom } from "../../store/game";
 import { playersAtom } from "../../store/players";
 import { socketAtom } from "../../store/socket";
+import Video from "../Video/Video.component";
 
 const CatchMind = () => {
   const [players, setPlayers] = useAtom(playersAtom);
@@ -105,7 +106,7 @@ const CatchMind = () => {
               setOutgoingCanvasStream={setOutgoingCanvasStream}
             />
           );
-        return <CanvasLayout />;
+        return <Video srcObject={incomingCanvasStream} />;
       case "gameEnd":
         return (
           <Rank
@@ -118,9 +119,9 @@ const CatchMind = () => {
           />
         );
       case "inputKeyword":
-        return <CanvasLayout />;
+        return <Video srcObject={incomingCanvasStream} />;
       case "roundEnd":
-        return <CanvasLayout />;
+        return <Video srcObject={incomingCanvasStream} />;
       default:
         return null;
     }

--- a/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
+++ b/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAtom, useAtomValue } from "jotai";
@@ -35,10 +35,18 @@ const CatchMind = () => {
   const [keyword, setKeyword] = useState("");
   const navigate = useNavigate();
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [outgoingCanvasStream, setOutgoingCanvasStream] =
+    useState<MediaStream | null>(null);
 
-  const { gamePlayerList, gameState, isMyTurn, roundEndInfo, roundInfo } =
-    useCatchMind(socket, players, gameInfo.roundInfo);
-
+  const {
+    gamePlayerList,
+    gameState,
+    isMyTurn,
+    roundEndInfo,
+    roundInfo,
+    incomingCanvasStream,
+  } = useCatchMind(socket, players, gameInfo.roundInfo, outgoingCanvasStream);
+  console.log(incomingCanvasStream);
   const { roundTime, currentRound, turnPlayer } = roundInfo;
 
   const getUserNameById = (id: string | undefined | null) => {
@@ -90,7 +98,13 @@ const CatchMind = () => {
   const getCenterElement = () => {
     switch (gameState) {
       case "drawing":
-        if (isMyTurn) return <Canvas canvasRef={canvasRef} />;
+        if (isMyTurn)
+          return (
+            <Canvas
+              canvasRef={canvasRef}
+              setOutgoingCanvasStream={setOutgoingCanvasStream}
+            />
+          );
         return <CanvasLayout />;
       case "gameEnd":
         return (

--- a/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
+++ b/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
@@ -121,7 +121,14 @@ const CatchMind = () => {
       case "inputKeyword":
         return <Video srcObject={incomingCanvasStream} />;
       case "roundEnd":
-        return <Video srcObject={incomingCanvasStream} />;
+        return isMyTurn ? (
+          <Canvas
+            canvasRef={canvasRef}
+            setOutgoingCanvasStream={setOutgoingCanvasStream}
+          />
+        ) : (
+          <Video srcObject={incomingCanvasStream} />
+        );
       default:
         return null;
     }

--- a/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
+++ b/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
@@ -15,6 +15,7 @@ import PaintBoard from "../../components/PaintBoard/PaintBoard.component";
 import {
   KeywordInputLayout,
   PaintBoardButtonLayout,
+  PaintBoardEmptyCenterElement,
 } from "../../components/PaintBoard/PaintBoard.styles";
 import PaintToolBox from "../../components/PaintToolBox/PaintToolBox.component";
 import PlayerList from "../../components/PlayerList/PlayerList.component";
@@ -119,7 +120,7 @@ const CatchMind = () => {
           />
         );
       case "inputKeyword":
-        return <Video srcObject={incomingCanvasStream} />;
+        return <PaintBoardEmptyCenterElement />;
       case "roundEnd":
         return isMyTurn ? (
           <Canvas

--- a/packages/frontend/src/components/PaintBoard/PaintBoard.styles.tsx
+++ b/packages/frontend/src/components/PaintBoard/PaintBoard.styles.tsx
@@ -8,6 +8,10 @@ export const PaintBoardCenterElementMixin = css`
   background-color: ${(props) => props.theme.colors.white};
 `;
 
+export const PaintBoardEmptyCenterElement = styled.div`
+  ${PaintBoardCenterElementMixin}
+`;
+
 export const PaintBoardHeader = styled.header`
   padding: 12px;
   border-radius: 10px;

--- a/packages/frontend/src/components/PaintBoard/PaintBoard.styles.tsx
+++ b/packages/frontend/src/components/PaintBoard/PaintBoard.styles.tsx
@@ -1,4 +1,12 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
+
+export const PaintBoardCenterElementMixin = css`
+  width: 1036px;
+  height: 644px;
+  border: 2px solid ${(props) => props.theme.colors.primary};
+  border-radius: 10px;
+  background-color: ${(props) => props.theme.colors.white};
+`;
 
 export const PaintBoardHeader = styled.header`
   padding: 12px;

--- a/packages/frontend/src/components/Video/Video.component.tsx
+++ b/packages/frontend/src/components/Video/Video.component.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from "react";
+
+import { VideoLayout } from "./Video.styles";
+
+interface VideoProps {
+  srcObject: MediaProvider | null;
+}
+
+const Video = ({ srcObject }: VideoProps) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (!videoRef.current) return;
+
+    videoRef.current.srcObject = srcObject;
+  }, [srcObject]);
+
+  return <VideoLayout ref={videoRef} width={500} height={500} autoPlay />;
+};
+
+export default Video;

--- a/packages/frontend/src/components/Video/Video.component.tsx
+++ b/packages/frontend/src/components/Video/Video.component.tsx
@@ -11,7 +11,6 @@ const Video = ({ srcObject }: VideoProps) => {
 
   useEffect(() => {
     if (!videoRef.current) return;
-
     videoRef.current.srcObject = srcObject;
   }, [srcObject]);
 

--- a/packages/frontend/src/components/Video/Video.component.tsx
+++ b/packages/frontend/src/components/Video/Video.component.tsx
@@ -15,7 +15,7 @@ const Video = ({ srcObject }: VideoProps) => {
     videoRef.current.srcObject = srcObject;
   }, [srcObject]);
 
-  return <VideoLayout ref={videoRef} width={500} height={500} autoPlay />;
+  return <VideoLayout ref={videoRef} autoPlay />;
 };
 
 export default Video;

--- a/packages/frontend/src/components/Video/Video.styles.tsx
+++ b/packages/frontend/src/components/Video/Video.styles.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+import { PaintBoardCenterElementMixin } from "../PaintBoard/PaintBoard.styles";
+
+export const VideoLayout = styled.video`
+  ${PaintBoardCenterElementMixin};
+`;

--- a/packages/frontend/src/hooks/useCatchMind.tsx
+++ b/packages/frontend/src/hooks/useCatchMind.tsx
@@ -161,7 +161,7 @@ export const useCatchMind = (
     connectToPlayersToSendMyCanvasStream();
 
     return clearAllMediaConnection;
-  }, [outgoingCanvasStream, connectToPlayersToSendMyCanvasStream]);
+  }, [outgoingCanvasStream]);
 
   return {
     roundInfo,


### PR DESCRIPTION
## 관련 이슈

closes #81

## 작업 내역

- 캔버스 공유를 위한 WebRTC 연결 구현
- Video 컴포넌트 구현 및 전달받은 캔버스 스트림 재생
- 게임 내부 흐름이 의도한대로 흘러가도록 고침
