### PR TITLE
[FIX] 모두 방에 없는데 게임을 시작하는 오류 수정

### DIFF
--- a/packages/backend/src/domains/catchMind/entity/catchMind.service.ts
+++ b/packages/backend/src/domains/catchMind/entity/catchMind.service.ts
@@ -65,10 +65,9 @@ export class CatchMindService implements CatchMindInputPort {
       roundWinner: winner,
     });
 
-    if (game.isGameEnded) {
-      this.roomAPI.gameEnded(game.roomId);
-    } else {
+    if (!game.isGameEnded) {
       this.repository.save(game);
+      // this.roomAPI.gameEnded(game.roomId);
     }
   }
 

--- a/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
+++ b/packages/frontend/src/components/CatchMind/CatchMind.component.tsx
@@ -71,6 +71,7 @@ const CatchMind = () => {
   };
 
   const onGoToRoomClick = () => {
+    socket.emit("quit-game");
     navigate("/room", { replace: true });
   };
 


### PR DESCRIPTION
## 관련 이슈
closes #164 

## 작업 내역
- 방으로 이동 버튼 클릭 시 서버로 이벤트 전송 추가
- 캐치마인드 라운드 종료 시 게임이 종료되었더라도 방의 상태를 변경 안 하도록 변경