### PR TITLE
[FIX] Canvas에서 채우기 기능이 재대로 작동하지 않는 현상 수정 

### DIFF
--- a/packages/frontend/src/components/Canvas/Canvas.component.tsx
+++ b/packages/frontend/src/components/Canvas/Canvas.component.tsx
@@ -6,6 +6,7 @@ import { useAtomValue } from "jotai/utils";
 import { CanvasLayout } from "./Canvas.styles";
 import { findEdgePoints } from "./utils/canvas";
 import Ellipse from "./utils/Ellipse";
+import { floodFill } from "./utils/floodfill";
 import Line from "./utils/Line";
 import Polygon from "./utils/Polygon";
 import Rectangle from "./utils/Rectangle";
@@ -95,15 +96,10 @@ const Canvas = ({ canvasRef, setOutgoingCanvasStream }: CanvasProps) => {
     );
 
     if (tool === "fill") {
-      if (!canvasRef.current) return;
-      const polygon = new Polygon(
-        color,
-        transparency,
-        10,
-        findEdgePoints(canvasRef.current, currentPoint)
-      );
-      shapeList.current.push(polygon);
-      drawAllShapes();
+      const ctx = canvasRef.current?.getContext("2d");
+      if (!canvasRef.current || !ctx) return;
+      ctx.fillStyle = color;
+      floodFill(ctx, Math.floor(currentPoint.x), Math.floor(currentPoint.y));
       return;
     }
 

--- a/packages/frontend/src/components/Canvas/Canvas.component.tsx
+++ b/packages/frontend/src/components/Canvas/Canvas.component.tsx
@@ -4,11 +4,9 @@ import { useAtom } from "jotai";
 import { useAtomValue } from "jotai/utils";
 
 import { CanvasLayout } from "./Canvas.styles";
-import { findEdgePoints } from "./utils/canvas";
 import Ellipse from "./utils/Ellipse";
 import { floodFill } from "./utils/floodfill";
 import Line from "./utils/Line";
-import Polygon from "./utils/Polygon";
 import Rectangle from "./utils/Rectangle";
 import Shape from "./utils/Shape";
 import straightLine from "./utils/StraightLine";

--- a/packages/frontend/src/components/Canvas/Canvas.component.tsx
+++ b/packages/frontend/src/components/Canvas/Canvas.component.tsx
@@ -5,6 +5,7 @@ import { useAtomValue } from "jotai/utils";
 
 import { CanvasLayout } from "./Canvas.styles";
 import Ellipse from "./utils/Ellipse";
+import FillShape from "./utils/FillShape";
 import { floodFill } from "./utils/floodfill";
 import Line from "./utils/Line";
 import Rectangle from "./utils/Rectangle";
@@ -96,8 +97,10 @@ const Canvas = ({ canvasRef, setOutgoingCanvasStream }: CanvasProps) => {
     if (tool === "fill") {
       const ctx = canvasRef.current?.getContext("2d");
       if (!canvasRef.current || !ctx) return;
-      ctx.fillStyle = color;
-      floodFill(ctx, Math.floor(currentPoint.x), Math.floor(currentPoint.y));
+      const fillShape = new FillShape(color, transparency, 0, currentPoint);
+      fillShape.draw(ctx);
+      shapeList.current.push(fillShape);
+
       return;
     }
 

--- a/packages/frontend/src/components/Canvas/utils/FillShape.ts
+++ b/packages/frontend/src/components/Canvas/utils/FillShape.ts
@@ -1,0 +1,34 @@
+import { getCanvasContextSetting, setCanvasContextSetting } from "./canvas";
+import { floodFill } from "./floodfill";
+import { Point } from "./Point";
+import Shape from "./Shape";
+
+export default class FillShape extends Shape {
+  protected point: Point;
+
+  constructor(
+    color: string,
+    transparency: number,
+    lineWidth: number,
+    point: Point
+  ) {
+    super(color, transparency, lineWidth);
+    this.point = {
+      x: Math.floor(point.x),
+      y: Math.floor(point.y),
+    };
+  }
+
+  draw(ctx: CanvasRenderingContext2D) {
+    const prevCtxSetting = getCanvasContextSetting(ctx);
+    setCanvasContextSetting(ctx, {
+      fillStyle: this.color,
+      globalAlpha: this.transparency,
+    });
+
+    const { x, y } = this.point;
+    floodFill(ctx, x, y);
+
+    setCanvasContextSetting(ctx, prevCtxSetting);
+  }
+}

--- a/packages/frontend/src/components/Canvas/utils/canvas.ts
+++ b/packages/frontend/src/components/Canvas/utils/canvas.ts
@@ -1,5 +1,3 @@
-import { Point } from "./Point";
-
 interface CanvasContextSetting {
   fillStyle?: string | CanvasGradient | CanvasPattern;
   strokeStyle?: string | CanvasGradient | CanvasPattern;
@@ -35,71 +33,4 @@ export const setCanvasContextSetting = (
   if (globalAlpha !== undefined) {
     ctx.globalAlpha = globalAlpha > 1 ? 1 : globalAlpha;
   }
-};
-
-export const findEdgePoints = (
-  canvas: HTMLCanvasElement,
-  point: Point
-): Point[] => {
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return [];
-  const edgePoints = [];
-  const pointStrSet = new Set();
-  const stack: Point[] = [point];
-  const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
-
-  // dfs 방향
-  const directions = [
-    [0, 1],
-    [1, 0],
-    [0, -1],
-    [-1, 0],
-  ];
-
-  // image data 의 특정 픽셀 접근용 유틸 함수
-  const getColorIndicesForCoord = (x: number, y: number, width: number) => {
-    const i = y * (width * 4) + x * 4;
-    return [i, i + 1, i + 2, i + 3];
-  };
-
-  // iterative dfs
-  while (stack.length) {
-    const { x, y } = stack.pop()!;
-    if (x < 0 || y < 0 || x > canvas.width - 1 || y > canvas.height - 1) {
-      edgePoints.push({ x, y });
-      continue;
-    }
-
-    const [r, g, b, a] = getColorIndicesForCoord(x, y, canvas.width);
-    const isEmpty = data[r] + data[g] + data[b] + data[a] === 0;
-
-    if (!isEmpty) {
-      edgePoints.push({ x, y });
-      continue;
-    }
-
-    for (const [dy, dx] of directions) {
-      const pointStr = `${y + dy} ${x + dx}`;
-      if (pointStrSet.has(pointStr)) {
-        continue;
-      }
-
-      pointStrSet.add(pointStr);
-      stack.push({
-        x: x + dx,
-        y: y + dy,
-      });
-    }
-  }
-
-  const getAngle = (point: Point, centerPoint: Point) =>
-    (Math.atan2(point.y - centerPoint.y, point.x - centerPoint.x) * 180) /
-    Math.PI;
-
-  // 시계 방향 정렬
-  const sortedEdgePoints = edgePoints.sort(
-    (p1, p2) => getAngle(p1, point) - getAngle(p2, point)
-  );
-
-  return sortedEdgePoints;
 };

--- a/packages/frontend/src/components/Canvas/utils/floodfill.ts
+++ b/packages/frontend/src/components/Canvas/utils/floodfill.ts
@@ -1,0 +1,146 @@
+interface PixelData {
+  width: number;
+  height: number;
+  data: Uint32Array;
+}
+
+type SpanDirection = -1 | 0 | 1;
+
+interface Span {
+  left: number;
+  right: number;
+  y: number;
+  direction: SpanDirection;
+}
+
+const getPixel = (pixelData: PixelData, x: number, y: number) => {
+  if (x < 0 || y < 0 || x > pixelData.width || y > pixelData.height) {
+    return -1;
+  }
+
+  return pixelData.data[y * pixelData.width + x];
+};
+
+export const floodFill = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number
+) => {
+  // canvas의 픽셀 정보 읽어오기
+  const imageData = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+  // fillColor 알아내기
+  const targetColor = new Uint32Array(
+    ctx.getImageData(x, y, 1, 1).data.buffer
+  )[0];
+  ctx.fillRect(x, y, 1, 1);
+  const fillColor = new Uint32Array(
+    ctx.getImageData(x, y, 1, 1).data.buffer
+  )[0];
+
+  // 이전 픽셀과 채우려는 픽셀이 같은 경우 작동 안함!
+  if (targetColor === fillColor) return;
+
+  // make a Uint32Array view on the pixels so we can manipulate pixels
+  // r, g, b, a 1바이트씩 각각 접근하는 것보다, 4바이트 하나로 뭉쳐버린 후 접근하는게 반복을 25%로 줄일 수 있음.
+  const pixelData = {
+    width: imageData.width,
+    height: imageData.height,
+    data: new Uint32Array(imageData.data.buffer),
+  };
+
+  // stack
+  const spansToCheck: Span[] = [];
+
+  const addSpan = (
+    left: number,
+    right: number,
+    y: number,
+    direction: SpanDirection
+  ) => {
+    spansToCheck.push({ left, right, y, direction });
+  };
+
+  // left부터 right까지 스캔하면서, span을 수집한다.
+  // 가로로 0 0 0 0 0 1 0 0 0 의 픽셀 데이터가 있을 때, (0 0 0 0 0)과 (0 0 0)의 정보를 얻어 내는 것.
+  const checkSpan = (
+    left: number,
+    right: number,
+    y: number,
+    direction: SpanDirection
+  ) => {
+    let start: number | undefined;
+    let x;
+
+    // 오른쪽으로 이동하면서
+    for (x = left; x < right; x++) {
+      const color = getPixel(pixelData, x, y);
+
+      if (color === targetColor) {
+        // targetColor 처음 만났을 때
+        if (!start) {
+          // start를 현재 x로 설정해준다
+          start = x;
+        }
+      } else {
+        // targetColor가 아닌 경우
+        // 이전에 targetColor를 만난적이 있는 경우 addSpan = span 하나 수집!
+        if (start) {
+          addSpan(start, x - 1, y, direction);
+          start = 0;
+        }
+      }
+    }
+
+    // 이전에 targetColor를 만난적이 있는 경우 addSpan
+    if (start) {
+      addSpan(start, x - 1, y, direction);
+    }
+  };
+
+  // 색깔을 감지할 때까지 x축 끝까지 이동
+  const findSpanEdge = (x: number, y: number, direction: -1 | 1) => {
+    // 범위 벗어난 경우 -1로 처리되어 무한루프의 가능성 없음
+    while (getPixel(pixelData, x, y) === targetColor) {
+      x += direction;
+    }
+
+    return x;
+  };
+
+  // 초기 위치
+  addSpan(x, x, y, 0);
+
+  // iterative dfs 시작
+  while (spansToCheck.length > 0) {
+    const span = spansToCheck.pop();
+    if (!span) continue;
+    const { left, right, y, direction } = span;
+
+    // 좌, 우 끝까지 확장
+    const l = findSpanEdge(left, y, -1) + 1;
+    const r = findSpanEdge(right, y, 1) + 1;
+
+    const lineOffset = y * pixelData.width;
+
+    // 왼쪽, 오른쪽 끝까지 확장 시킨 l, r을 이용해 한번에 채우기(가로로 쭉)
+    pixelData.data.fill(fillColor, lineOffset + l, lineOffset + r);
+
+    if (direction <= 0) {
+      checkSpan(l, r, y - 1, -1);
+    } else {
+      checkSpan(l, left, y - 1, -1);
+      checkSpan(right, r, y - 1, -1);
+    }
+
+    if (direction >= 0) {
+      checkSpan(l, r, y + 1, 1);
+    } else {
+      checkSpan(l, left, y + 1, 1);
+      checkSpan(right, r, y + 1, 1);
+    }
+  }
+
+  // 변경된 이미지 데이터를 다시 쓰기
+  ctx.putImageData(imageData, 0, 0);
+};


### PR DESCRIPTION
## 관련 이슈

closes #167

## 작업 내역

- 기존의 Polygon 객체를 사용하던 채우기 알고리즘을 floodfill 알고리즘으로 변경. 
- 최적화를 위해 해당 링크를 많이 참조하였음. https://stackoverflow.com/questions/2106995/how-can-i-perform-flood-fill-with-html-canvas/56221940#56221940
-  FillShape 객체 구현하여 채우기 작업을 undo 하거나, 추후에 다시 그릴 수 있도록 사용함.
