### PR TITLE
[FEAT] 페이지 이동시 채팅내역 유지

### DIFF
--- a/packages/frontend/src/components/Chat/Chat.component.tsx
+++ b/packages/frontend/src/components/Chat/Chat.component.tsx
@@ -1,27 +1,23 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 
 import { ChatInputForm, ChatLayout } from "./Chat.styles";
 import ChatBubble from "./ChatBubble.component";
 
+import { chatAtom, ChatData } from "../../store/chat";
 import { playersAtom } from "../../store/players";
 import { socketAtom } from "../../store/socket";
 import { Button } from "../common/Button";
 import { Input } from "../common/Input";
 import Icon from "../Icon/Icon";
 
-interface ChatData {
-  id: string;
-  message: string;
-}
-
 interface ChatProps {
   variant?: "horizontal";
 }
 
 const Chat = ({ variant }: ChatProps) => {
-  const [chats, setChats] = useState<ChatData[]>([]);
+  const [chats, setChats] = useAtom(chatAtom);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const chatInputRef = useRef<HTMLInputElement>(null);
   const socket = useAtomValue(socketAtom);
@@ -55,11 +51,10 @@ const Chat = ({ variant }: ChatProps) => {
     return () => {
       socket.off("chatting", chatListener);
     };
-  }, [socket]);
+  }, [socket, setChats]);
 
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    console.log(chats);
   }, [chats]);
 
   return (

--- a/packages/frontend/src/components/Chat/Chat.component.tsx
+++ b/packages/frontend/src/components/Chat/Chat.component.tsx
@@ -30,6 +30,8 @@ const Chat = ({ variant }: ChatProps) => {
   const onChatSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!chatInputRef.current || !chatInputRef.current.value) return;
+    const trimmedText = chatInputRef.current.value.trim();
+    if (!trimmedText) return;
 
     const newChat = {
       id: socket.id,

--- a/packages/frontend/src/store/chat.ts
+++ b/packages/frontend/src/store/chat.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+
+export interface ChatData {
+  id: string;
+  message: string;
+}
+
+export const chatAtom = atom<ChatData[]>([]);


### PR DESCRIPTION
## 관련 이슈

closes #153 

## 작업 내역

- 채팅 내역 전역으로 관리
- 공백문자만 있는 경우 채팅 전송 하지 않도록 변경