### PR TITLE
[FEAT] 방장의 게임모드 설정을 방 인원에게 표시

### DIFF
--- a/packages/frontend/src/components/GameModeSegmentedControl/GameModeSegmentedControl.component.tsx
+++ b/packages/frontend/src/components/GameModeSegmentedControl/GameModeSegmentedControl.component.tsx
@@ -1,3 +1,7 @@
+import { useEffect } from "react";
+
+import { useAtomValue } from "jotai";
+
 import {
   GameModeSegmentedControlLayout,
   GameModeButtonLayout,
@@ -12,19 +16,35 @@ import {
   GAME_MODE_TITLE_MAP,
   GAME_MODE_DESCRIPTION_MAP,
 } from "../../constants/game-mode";
+import { socketAtom } from "../../store/socket";
 
 interface GameModeSegmentedControlProps {
   selectedGameMode: GameMode;
   setSelectedGameMode: React.Dispatch<React.SetStateAction<GameMode>>;
+  disabled: boolean;
 }
 
 const GameModeSegmentedControl = ({
   selectedGameMode,
   setSelectedGameMode,
+  disabled,
 }: GameModeSegmentedControlProps) => {
+  const socket = useAtomValue(socketAtom);
   const onChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    if (disabled) return;
     setSelectedGameMode(e.target.value as GameMode);
+    socket.emit("mode-change", { gameMode: e.target.value });
   };
+
+  useEffect(() => {
+    const modeChangeListener = ({ gameMode }: { gameMode: GameMode }) => {
+      setSelectedGameMode(gameMode);
+    };
+    socket.on("mode-change", modeChangeListener);
+    return () => {
+      socket.off("mode-change", modeChangeListener);
+    };
+  }, [socket, setSelectedGameMode]);
 
   return (
     <GameModeSegmentedControlLayout>
@@ -38,6 +58,7 @@ const GameModeSegmentedControl = ({
             value={gameMode}
             name="game-mode"
             onChange={onChangeHandler}
+            disabled={disabled}
           />
           <GameModeTitle>{GAME_MODE_TITLE_MAP[gameMode]}</GameModeTitle>
           <GameModeDescriptionParagraph>

--- a/packages/frontend/src/components/GameModeSegmentedControl/GameModeSegmentedControl.styles.tsx
+++ b/packages/frontend/src/components/GameModeSegmentedControl/GameModeSegmentedControl.styles.tsx
@@ -19,6 +19,9 @@ export const GameModeButton = styled.input`
   border-radius: ${GAME_MODE_BUTTON_BORDER_RADIUS};
   opacity: 0;
   cursor: pointer;
+  &:disabled {
+    cursor: not-allowed;
+  }
 `;
 
 export const GameModeTitle = styled.h2`

--- a/packages/frontend/src/pages/RoomPage/RoomPage.component.tsx
+++ b/packages/frontend/src/pages/RoomPage/RoomPage.component.tsx
@@ -151,6 +151,7 @@ const RoomPage = () => {
             <GameModeSegmentedControl
               selectedGameMode={gameMode}
               setSelectedGameMode={setGameMode}
+              disabled={!isHost}
             />
             <RoomPageButtonBox>
               <Button variant="medium" onClick={onInviteClick}>


### PR DESCRIPTION
## 관련 이슈

closes #157 

## 작업 내역

- 방장이 게임 모드 변경 시 나머지 플레이어에게 전파
- 방장이 아닌 경우 선택하지 못하도록 변경