### PR TITLE
[FIX] 앨범 이미지 스크롤 오류 수정

### DIFF
--- a/packages/frontend/src/components/Album/Album.component.tsx
+++ b/packages/frontend/src/components/Album/Album.component.tsx
@@ -42,10 +42,14 @@ const Album = ({ album, isLastAlbum }: AlbumProps) => {
     socket.id && players.find(({ isHost }) => isHost)?.peerId === socket.id;
 
   useEffect(() => {
-    setTimeout(() => {
-      albumEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-    }, 50);
-  }, [renderedAlbum, showNext]);
+    albumEndRef.current?.scrollIntoView();
+  }, [showNext]);
+
+  useEffect(() => {
+    if (renderedAlbum.at(-1)?.keyword) {
+      albumEndRef.current?.scrollIntoView();
+    }
+  }, [renderedAlbum]);
 
   useEffect(() => {
     setShowNext(false);
@@ -74,6 +78,10 @@ const Album = ({ album, isLastAlbum }: AlbumProps) => {
     };
   }, [album, isLastAlbum, setPlayers]);
 
+  const onImageLoad = () => {
+    albumEndRef.current?.scrollIntoView();
+  };
+
   const onNextClick = () => {
     socket.emit("request-album");
   };
@@ -91,7 +99,11 @@ const Album = ({ album, isLastAlbum }: AlbumProps) => {
           isRightSide={!img}
           username={getUserNameById(peerId) ?? ""}
         >
-          {img ? <img src={img} alt="result" width={460} /> : keyword}
+          {img ? (
+            <img src={img} alt="result" width={460} onLoad={onImageLoad} />
+          ) : (
+            keyword
+          )}
         </AlbumBubble>
       ))}
       {showNext && (

--- a/packages/frontend/src/components/Album/Album.component.tsx
+++ b/packages/frontend/src/components/Album/Album.component.tsx
@@ -42,7 +42,9 @@ const Album = ({ album, isLastAlbum }: AlbumProps) => {
     socket.id && players.find(({ isHost }) => isHost)?.peerId === socket.id;
 
   useEffect(() => {
-    albumEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    setTimeout(() => {
+      albumEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    }, 50);
   }, [renderedAlbum, showNext]);
 
   useEffect(() => {

--- a/packages/frontend/src/components/Chat/Chat.component.tsx
+++ b/packages/frontend/src/components/Chat/Chat.component.tsx
@@ -56,7 +56,7 @@ const Chat = ({ variant }: ChatProps) => {
   }, [socket, setChats]);
 
   useEffect(() => {
-    chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    chatEndRef.current?.scrollIntoView();
   }, [chats]);
 
   return (


### PR DESCRIPTION
## 관련 이슈

closes #227 

## 작업 내역

- 앨범 이미지 스크롤 오류 수정
  - 50ms 딜레이를 주고 스크롤하도록 변경

![Dec-12-2022 15-00-29](https://user-images.githubusercontent.com/96206089/206971406-4453d326-2864-4f6f-96aa-696e0ad74d83.gif)