### PR TITLE
[FEAT] 앨범 표시할 때 플레이어 닉네임 추가

### DIFF
--- a/packages/frontend/src/components/Album/Album.component.tsx
+++ b/packages/frontend/src/components/Album/Album.component.tsx
@@ -94,7 +94,9 @@ const Album = ({ album, isLastAlbum }: AlbumProps) => {
       ))}
       {showNext && (
         <AlbumNextLayout>
-          <AlbumNextText>OOO님의 앨범</AlbumNextText>
+          <AlbumNextText>
+            {getUserNameById(renderedAlbum[0]?.peerId)}님의 앨범
+          </AlbumNextText>
           <AlbumNextButtonBox>
             <Button variant="icon">
               <Icon icon="download" size={36} />


### PR DESCRIPTION
## 관련 이슈

closes #218 

## 작업 내역

- 앨범 마지막에 해당 앨범을 소유하는 플레이어의 닉네임 출력