### PR TITLE
[FEAT] 캐치마인드 라운드와 목표 점수를 플레이어 수에 따라 조정

### DIFF
--- a/packages/backend/src/domains/catchMind/entity/catchMind.ts
+++ b/packages/backend/src/domains/catchMind/entity/catchMind.ts
@@ -38,12 +38,14 @@ export class CatchMind {
   turnPlayerIdx: number;
 
   constructor(data: CatchMindData) {
+    const [goalScore, totalRound] = this.calcGameData(data.players.length);
+
     this.players = data.players;
-    this.goalScore = data.goalScore;
+    this.goalScore = goalScore;
     this.keyword = data.keyword || "";
     this.currentRound = data.currentRound || 1;
     this.roundTime = data.roundTime;
-    this.totalRound = data.totalRound;
+    this.totalRound = totalRound;
     this.roomId = data.roomId;
     this.turnPlayerIdx = data.turnPlayerIdx || 0;
   }
@@ -81,6 +83,10 @@ export class CatchMind {
       playerScoreMap[player.id] = player.score;
     });
     return playerScoreMap;
+  }
+
+  calcGameData(playerNum: number) {
+    return [Math.ceil(Math.sqrt(playerNum * 2)), playerNum * 2];
   }
 
   nextTurn() {

--- a/packages/backend/src/domains/catchMind/useCases/catchMind.service.ts
+++ b/packages/backend/src/domains/catchMind/useCases/catchMind.service.ts
@@ -32,10 +32,9 @@ export class CatchMindService implements CatchMindInputPort {
       totalRound,
     });
 
-    const { roundInfo } = game;
     this.eventEmitter.gameStart(game.roomId, {
-      totalRound,
-      roundInfo,
+      totalRound: game.totalRound,
+      roundInfo: game.roundInfo,
     });
 
     console.log("\x1b[32mstart CatchMind\x1b[37m", roomId);


### PR DESCRIPTION
## 관련 이슈

closes #219 

## 작업 내역

- 목표 점수 및 라운드 수 계산 로직 구현